### PR TITLE
draft: make panes configurable in SandpackEditor

### DIFF
--- a/src/system/Sandpack.ts
+++ b/src/system/Sandpack.ts
@@ -68,6 +68,16 @@ export interface SandpackConfig {
    * The list of sandpack presets that can be used.
    */
   presets: Array<SandpackPreset>
+  /**
+   * The list of sandpack panes that will be displayed in the sandbox.
+   */
+  panes?: {
+    editor?: boolean
+    console?: boolean
+    preview?: boolean
+    test?: boolean
+  }
+  readonly?: boolean
 }
 
 const defaultSnippetContent = `
@@ -94,7 +104,11 @@ const defaultSandpackConfig: SandpackConfig = {
       snippetLanguage: 'jsx',
       initialSnippetContent: defaultSnippetContent
     }
-  ]
+  ],
+  panes: {
+    editor: true,
+    preview: true
+  }
 }
 
 const defaultCodeBlockLanguages = {

--- a/src/system/Sandpack.ts
+++ b/src/system/Sandpack.ts
@@ -77,7 +77,6 @@ export interface SandpackConfig {
     preview?: boolean
     test?: boolean
   }
-  readonly?: boolean
 }
 
 const defaultSnippetContent = `

--- a/src/ui/NodeDecorators/SandpackEditor.tsx
+++ b/src/ui/NodeDecorators/SandpackEditor.tsx
@@ -1,4 +1,12 @@
-import { SandpackCodeEditor, SandpackLayout, SandpackPreview, SandpackProvider, useSandpack } from '@codesandbox/sandpack-react'
+import {
+  SandpackCodeEditor,
+  SandpackCodeViewer,
+  SandpackConsole,
+  SandpackLayout,
+  SandpackPreview,
+  SandpackProvider,
+  useSandpack
+} from '@codesandbox/sandpack-react'
 import { useLexicalComposerContext } from '@lexical/react/LexicalComposerContext'
 import React from 'react'
 import { useEmitterValues, usePublisher } from '../../system/EditorSystemComponent'
@@ -64,8 +72,13 @@ export const SandpackEditor = ({ nodeKey, code, meta, onChange, focusEmitter }: 
       }}
     >
       <SandpackLayout>
-        <SandpackCodeEditor showLineNumbers showInlineErrors ref={codeMirrorRef} />
-        <SandpackPreview />
+        {config.readonly ? (
+          <SandpackCodeViewer showLineNumbers ref={codeMirrorRef} />
+        ) : (
+          <SandpackCodeEditor showLineNumbers showInlineErrors ref={codeMirrorRef} />
+        )}
+        {config.panes?.console ?? <SandpackConsole />}
+        {config.panes?.preview ?? <SandpackPreview />}
       </SandpackLayout>
       <CodeUpdateEmitter onChange={wrappedOnChange} snippetFileName={preset.snippetFileName} />
     </SandpackProvider>

--- a/src/ui/NodeDecorators/SandpackEditor.tsx
+++ b/src/ui/NodeDecorators/SandpackEditor.tsx
@@ -1,6 +1,5 @@
 import {
   SandpackCodeEditor,
-  SandpackCodeViewer,
   SandpackConsole,
   SandpackLayout,
   SandpackPreview,
@@ -72,11 +71,7 @@ export const SandpackEditor = ({ nodeKey, code, meta, onChange, focusEmitter }: 
       }}
     >
       <SandpackLayout>
-        {config.readonly ? (
-          <SandpackCodeViewer showLineNumbers ref={codeMirrorRef} />
-        ) : (
-          <SandpackCodeEditor showLineNumbers showInlineErrors ref={codeMirrorRef} />
-        )}
+        <SandpackCodeEditor showLineNumbers showInlineErrors ref={codeMirrorRef} />
         {config.panes?.console ?? <SandpackConsole />}
         {config.panes?.preview ?? <SandpackPreview />}
       </SandpackLayout>


### PR DESCRIPTION
Use case: 
Besides configuring the `preset` I would like to be able to control the `panes` presented to the editor.