### PR TITLE
feat: expose focus() on rootEditor

### DIFF
--- a/src/MDXEditor.tsx
+++ b/src/MDXEditor.tsx
@@ -139,6 +139,11 @@ export interface MDXEditorMethods {
    * Updates the markdown value of the editor.
    */
   setMarkdown: (value: string) => void
+
+  /**
+   * Sets focus on input
+   */
+  focus: () => void
 }
 
 const RenderRecurisveWrappers: React.FC<{ wrappers: React.ComponentType<{ children: React.ReactNode }>[]; children: React.ReactNode }> = ({
@@ -185,6 +190,9 @@ const Methods: React.FC<{ mdxRef: React.ForwardedRef<MDXEditorMethods> }> = ({ m
         },
         setMarkdown: (markdown) => {
           realm.pubKey('setMarkdown', markdown)
+        },
+        focus: () => {
+          realm.getKeyValue('rootEditor')?.focus()
         }
       }
     },


### PR DESCRIPTION
# Pull Request

## Issues Closed
Closes #56

## Summary of Change
Adds `focus` method to MDXEditorMethods for functionally focusing input field.
