### PR TITLE
feat: add onBlur triggered by inFocus listener

### DIFF
--- a/src/MDXEditor.tsx
+++ b/src/MDXEditor.tsx
@@ -106,6 +106,10 @@ export interface MDXEditorProps {
    */
   autoFocus?: boolean
   /**
+   * Triggered when focus leaves input
+   */
+  onBlur?: () => void
+  /**
    * The placeholder contents, displayed when the editor is empty.
    */
   placeholder?: React.ReactNode
@@ -212,6 +216,7 @@ export const MDXEditor = React.forwardRef<MDXEditorMethods, MDXEditorProps>((pro
           contentEditableClassName: props.contentEditableClassName ?? '',
           initialMarkdown: props.markdown,
           onChange: props.onChange ?? noop,
+          onBlur: props.onBlur ?? noop,
           toMarkdownOptions: props.toMarkdownOptions ?? DEFAULT_MARKDOWN_OPTIONS,
           autoFocus: props.autoFocus ?? false,
           placeholder: props.placeholder ?? '',

--- a/src/plugins/core/index.ts
+++ b/src/plugins/core/index.ts
@@ -479,6 +479,7 @@ interface CorePluginParams {
   placeholder?: React.ReactNode
   autoFocus: boolean
   onChange: (markdown: string) => void
+  onBlur: () => void
   toMarkdownOptions: NonNullable<LexicalConvertOptions['toMarkdownOptions']>
   readOnly: boolean
 }
@@ -501,6 +502,7 @@ export const [
       readOnly: params.readOnly
     })
     realm.singletonSubKey('markdown', params.onChange)
+    realm.singletonSubKey('inFocus', (focus) => !focus && params.onBlur?.())
   },
 
   init(realm, params: CorePluginParams) {


### PR DESCRIPTION
Closes #55
Lets user pass onBlur prop to listen for blur event.

