### PR TITLE
fix: ensure JSX popover is displayed on top of toolbar

### DIFF
--- a/src/styles/ui.module.css
+++ b/src/styles/ui.module.css
@@ -610,6 +610,7 @@
   background-color: var(--baseBgSubtle);
   padding:var(--spacing-2) var(--spacing-2);
   font-size: var(--text-sm);
+  z-index: 1;
 }
 
 .popoverArrow {


### PR DESCRIPTION
Very small UI bug I found when the editor is a little way down the page - the JSX popover can conflict with the toolbar:

![Screenshot 2023-09-08 at 08 56 11](https://github.com/mdx-editor/editor/assets/98081005/8d62c4a1-0485-42b9-853d-73a20bc772b6)


To reproduce, add some padding to the JSX Example:

```jsx
    <div style={{ paddingTop: 100 }}>
      <MDXEditor
        markdown={jsxMarkdown}
        onChange={console.log}
        plugins={[
          jsxPlugin({ jsxComponentDescriptors }),
          toolbarPlugin({
            toolbarContents: () => (
              <>
                <InsertMyLeaf />
              </>
            )
          })
        ]}
      />
    </div>
```

Incrementing `z-index` seems to fix.
