### PR TITLE
fix(link-dialog): stop button submit event propagation

### DIFF
--- a/src/plugins/link-dialog/LinkDialog.tsx
+++ b/src/plugins/link-dialog/LinkDialog.tsx
@@ -73,6 +73,10 @@ export function LinkEditForm({ initialUrl, initialTitle, onSubmit, onCancel, lin
     [isOpen, items, onSubmit, title]
   )
 
+  const handleSaveClick = (event: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
+    event.stopPropagation()
+  }
+
   const downshiftInputProps = getInputProps()
 
   const inputProps = {
@@ -126,7 +130,7 @@ export function LinkEditForm({ initialUrl, initialTitle, onSubmit, onCancel, lin
         <button type="reset" title="Cancel change" aria-label="Cancel change" className={classNames(styles.secondaryButton)}>
           Cancel
         </button>
-        <button type="submit" title="Set URL" aria-label="Set URL" className={classNames(styles.primaryButton)}>
+        <button type="submit" title="Set URL" aria-label="Set URL" className={classNames(styles.primaryButton)} onClick={handleSaveClick}>
           Save
         </button>
       </div>


### PR DESCRIPTION
Hey! :wave:

Thanks for this awesome library! :smile:

Found a small bug, where the link dialog is already in a form, when clicking on the button, it submits both forms, but we only need to submit the link dialog form.

Thanks!