### PR TITLE
fix: add MDXEditor classnames to popup container

### DIFF
--- a/src/MDXEditor.tsx
+++ b/src/MDXEditor.tsx
@@ -172,13 +172,18 @@ const EditorRootElement: React.FC<{ children: React.ReactNode; className?: strin
   React.useEffect(() => {
     const popupContainer = document.createElement('div')
     popupContainer.classList.add(styles.editorRoot)
+    if (className) {
+      className.split(' ').forEach((_className) => {
+        popupContainer.classList.add(_className);
+      });
+    }
     document.body.appendChild(popupContainer)
     editorRootElementRef.current = popupContainer
     setEditorRootElementRef(editorRootElementRef)
     return () => {
       document.body.removeChild(popupContainer)
     }
-  }, [editorRootElementRef, setEditorRootElementRef])
+  }, [className, editorRootElementRef, setEditorRootElementRef])
   return <div className={classNames(styles.editorRoot, styles.editorWrapper, className, 'mdxeditor')}>{children}</div>
 }
 

--- a/src/MDXEditor.tsx
+++ b/src/MDXEditor.tsx
@@ -173,8 +173,8 @@ const EditorRootElement: React.FC<{ children: React.ReactNode; className?: strin
     const popupContainer = document.createElement('div')
     popupContainer.classList.add(styles.editorRoot)
     if (className) {
-      className.split(' ').forEach((_className) => {
-        popupContainer.classList.add(_className);
+      className.split(' ').forEach((c) => {
+        popupContainer.classList.add(c);
       });
     }
     document.body.appendChild(popupContainer)


### PR DESCRIPTION
Hey there! Thanks for the awesome work on this!

I was running into a small issue when enabling dark mode. The class was correctly assigned to the MDXEditor, but not to the popup container. Therefore, the toolbar dropdowns and popups were still rendering with the light theme.

Thanks!