### PR TITLE
fix(link-dialog): Conditionaly render dropdown menu button

### DIFF
--- a/src/plugins/link-dialog/LinkDialog.tsx
+++ b/src/plugins/link-dialog/LinkDialog.tsx
@@ -97,9 +97,7 @@ export function LinkEditForm({ initialUrl, initialTitle, onSubmit, onCancel, lin
       <div className={styles.linkDialogInputContainer}>
         <div data-visible-dropdown={dropdownIsVisible} className={styles.linkDialogInputWrapper}>
           <input id="link-url" className={styles.linkDialogInput} {...inputProps} autoFocus size={40} data-editor-dialog={true} />
-          <button aria-label="toggle menu" type="button" {...getToggleButtonProps()}>
-            <DropDownIcon />
-          </button>
+          {items.length > 0 && <DropDownIcon className={styles.linkDialogDropDownIcon} {...getToggleButtonProps()} />}
         </div>
 
         <div className={styles.linkDialogAutocompleteContainer}>


### PR DESCRIPTION
Doesn't display the dropdown trigger, if no autocomplete suggestions are provided:
![image](https://github.com/mdx-editor/editor/assets/56349342/97e381f8-864b-4907-89b7-9a7490d3eed7)
