### PR TITLE
fix: Use preset.label in InsertSandpack dropdown item

### DIFF
--- a/src/plugins/toolbar/components/InsertSandpack.tsx
+++ b/src/plugins/toolbar/components/InsertSandpack.tsx
@@ -10,7 +10,7 @@ import { sandpackPluginHooks } from '../../sandpack'
 export const InsertSandpack = () => {
   const [sandpackConfig] = sandpackPluginHooks.useEmitterValues('sandpackConfig')
   const insertSandpack = sandpackPluginHooks.usePublisher('insertSandpack')
-  const items = React.useMemo(() => sandpackConfig.presets.map((preset) => ({ value: preset.name, label: preset.name })), [sandpackConfig])
+  const items = React.useMemo(() => sandpackConfig.presets.map((preset) => ({ value: preset.name, label: preset.label })), [sandpackConfig])
 
   return (
     <ButtonOrDropdownButton title="Insert Sandpack" onChoose={insertSandpack} items={items}>


### PR DESCRIPTION
The InsertSandpack dropdown currently uses `preset.name` as the label, we can use Sandpack `preset.label` in InsertSandpack dropdown item.