### PR TITLE
feat: Accept JSX.Element for various dropdown items

### DIFF
--- a/src/plugins/sandpack/index.tsx
+++ b/src/plugins/sandpack/index.tsx
@@ -18,7 +18,7 @@ export interface SandpackPreset {
   /**
    * The label of the preset, displayed in the sandpack button dropdown.
    */
-  label: string
+  label: string | JSX.Element
   /**
    * The meta string that will be used to identify the preset from the fenced code block. e.g. "live react"
    */

--- a/src/plugins/toolbar/components/BlockTypeSelect.tsx
+++ b/src/plugins/toolbar/components/BlockTypeSelect.tsx
@@ -19,7 +19,7 @@ export const BlockTypeSelect = () => {
   if (!hasQuote && !hasHeadings) {
     return null
   }
-  const items: { label: string; value: BlockType }[] = [{ label: 'Paragraph', value: 'paragraph' }]
+  const items: { label: string | JSX.Element; value: BlockType }[] = [{ label: 'Paragraph', value: 'paragraph' }]
 
   if (hasQuote) {
     items.push({ label: 'Quote', value: 'quote' })

--- a/src/plugins/toolbar/primitives/select.tsx
+++ b/src/plugins/toolbar/primitives/select.tsx
@@ -88,7 +88,7 @@ export interface SelectProps<T extends string> {
   onChange: (value: T) => void
   triggerTitle: string
   placeholder: string
-  items: ({ label: string; value: T } | 'separator')[]
+  items: ({ label: string | JSX.Element; value: T } | 'separator')[]
 }
 
 /**

--- a/src/plugins/toolbar/primitives/toolbar.tsx
+++ b/src/plugins/toolbar/primitives/toolbar.tsx
@@ -192,7 +192,7 @@ export interface ButtonOrDropdownButtonProps<T extends string> {
     /**
      * The label to show in the dropdown.
      */
-    label: string
+    label: string | JSX.Element
   }[]
 }
 


### PR DESCRIPTION
The current dropdown items in SandpackPreset/BlockTypeSelect/toolbar only accept string as label, we can support JSX.Element to allow customized dropdown item labels, e.g. icon with label in the toolbar dropdown items.