### PR TITLE
Feat editor dark theme extensions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4622,7 +4622,7 @@
       "version": "15.7.5",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.5.tgz",
       "integrity": "sha512-JCB8C6SnDoQf0cNycqd/35A7MjcnK+ZTqE7judS6o7utxUCg6imJg3QK2qzHKszlTjcj2cn+NwMB2i96ubpj7w==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/@types/qs": {
       "version": "6.9.7",
@@ -4640,7 +4640,7 @@
       "version": "18.2.16",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.2.16.tgz",
       "integrity": "sha512-LLFWr12ZhBJ4YVw7neWLe6Pk7Ey5R9OCydfuMsz1L8bZxzaawJj2p06Q8/EFEHDeTBQNFLF62X+CG7B2zIyu0Q==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "@types/prop-types": "*",
         "@types/scheduler": "*",
@@ -4651,7 +4651,7 @@
       "version": "18.2.7",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.2.7.tgz",
       "integrity": "sha512-GRaAEriuT4zp9N4p1i8BDBYmEyfo+xQ3yHjJU4eiK5NDa1RmUZG+unZABUTK4/Ox/M+GaHwb6Ow8rUITrtjszA==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "@types/react": "*"
       }
@@ -4660,7 +4660,7 @@
       "version": "0.16.3",
       "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.3.tgz",
       "integrity": "sha512-5cJ8CB4yAx7BH1oMvdU0Jh9lrEXyPkar6F9G/ERswkCuvP4KQZfZkSjcMbAICCpQTN4OuZn8tz0HiKv9TGZgrQ==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/@types/semver": {
       "version": "7.5.2",
@@ -6948,7 +6948,7 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.2.tgz",
       "integrity": "sha512-I7K1Uu0MBPzaFKg4nI5Q7Vs2t+3gWWW648spaF+Rg7pI9ds18Ugn+lvg4SHczUdKlHI5LWBXyqfS8+DufyBsgQ==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/d": {
       "version": "1.0.1",
@@ -10382,6 +10382,16 @@
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true
     },
+    "node_modules/isomorphic.js": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/isomorphic.js/-/isomorphic.js-0.2.5.tgz",
+      "integrity": "sha512-PIeMbHqMt4DnUP3MA/Flc0HElYjMXArsw1qwJZcm9sqR8mq3l8NYizFMty0pWwE/tzIGH3EKK5+jes5mAr85yw==",
+      "peer": true,
+      "funding": {
+        "type": "GitHub Sponsors ❤",
+        "url": "https://github.com/sponsors/dmonad"
+      }
+    },
     "node_modules/issue-parser": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/issue-parser/-/issue-parser-6.0.0.tgz",
@@ -11255,6 +11265,26 @@
       "version": "0.12.2",
       "resolved": "https://registry.npmjs.org/lexical/-/lexical-0.12.2.tgz",
       "integrity": "sha512-Kxavd+ETjxtVwG/hvPd6WZfXD44sLOKe9Vlkwxy7lBQ1qZArS+rZfs+u5iXwXe6tX9f2PIM0u3RHsrCEDDE0fw=="
+    },
+    "node_modules/lib0": {
+      "version": "0.2.87",
+      "resolved": "https://registry.npmjs.org/lib0/-/lib0-0.2.87.tgz",
+      "integrity": "sha512-TbB63XJixvNToW2IHWAFsCJj9tVnajmwjE14p69i51Rx8byOQd2IP4ourE8v4d7vhyO++nVm1sQk3ePslfbucg==",
+      "peer": true,
+      "dependencies": {
+        "isomorphic.js": "^0.2.4"
+      },
+      "bin": {
+        "0gentesthtml": "bin/gentesthtml.js",
+        "0serve": "bin/0serve.js"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "type": "GitHub Sponsors ❤",
+        "url": "https://github.com/sponsors/dmonad"
+      }
     },
     "node_modules/lilconfig": {
       "version": "2.1.0",
@@ -13392,17 +13422,16 @@
     },
     "node_modules/npm/node_modules/@colors/colors": {
       "version": "1.5.0",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=0.1.90"
       }
     },
     "node_modules/npm/node_modules/@isaacs/cliui": {
       "version": "8.0.2",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -13419,7 +13448,7 @@
     },
     "node_modules/npm/node_modules/@isaacs/cliui/node_modules/ansi-regex": {
       "version": "6.0.1",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -13431,13 +13460,13 @@
     },
     "node_modules/npm/node_modules/@isaacs/cliui/node_modules/emoji-regex": {
       "version": "9.2.2",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/@isaacs/cliui/node_modules/string-width": {
       "version": "5.1.2",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -13454,7 +13483,7 @@
     },
     "node_modules/npm/node_modules/@isaacs/cliui/node_modules/strip-ansi": {
       "version": "7.1.0",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -13469,13 +13498,13 @@
     },
     "node_modules/npm/node_modules/@isaacs/string-locale-compare": {
       "version": "1.1.0",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npm/node_modules/@npmcli/arborist": {
       "version": "6.3.0",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -13522,7 +13551,7 @@
     },
     "node_modules/npm/node_modules/@npmcli/config": {
       "version": "6.2.1",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -13541,7 +13570,7 @@
     },
     "node_modules/npm/node_modules/@npmcli/disparity-colors": {
       "version": "3.0.0",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -13553,7 +13582,7 @@
     },
     "node_modules/npm/node_modules/@npmcli/fs": {
       "version": "3.1.0",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -13565,7 +13594,7 @@
     },
     "node_modules/npm/node_modules/@npmcli/git": {
       "version": "4.1.0",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -13584,7 +13613,7 @@
     },
     "node_modules/npm/node_modules/@npmcli/installed-package-contents": {
       "version": "2.0.2",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -13600,7 +13629,7 @@
     },
     "node_modules/npm/node_modules/@npmcli/map-workspaces": {
       "version": "3.0.4",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -13615,7 +13644,7 @@
     },
     "node_modules/npm/node_modules/@npmcli/metavuln-calculator": {
       "version": "5.0.1",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -13630,7 +13659,7 @@
     },
     "node_modules/npm/node_modules/@npmcli/name-from-folder": {
       "version": "2.0.0",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
@@ -13639,7 +13668,7 @@
     },
     "node_modules/npm/node_modules/@npmcli/node-gyp": {
       "version": "3.0.0",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
@@ -13648,7 +13677,7 @@
     },
     "node_modules/npm/node_modules/@npmcli/package-json": {
       "version": "4.0.1",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -13666,7 +13695,7 @@
     },
     "node_modules/npm/node_modules/@npmcli/promise-spawn": {
       "version": "6.0.2",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -13678,7 +13707,7 @@
     },
     "node_modules/npm/node_modules/@npmcli/query": {
       "version": "3.0.0",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -13690,7 +13719,7 @@
     },
     "node_modules/npm/node_modules/@npmcli/run-script": {
       "version": "6.0.2",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -13706,17 +13735,16 @@
     },
     "node_modules/npm/node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=14"
       }
     },
     "node_modules/npm/node_modules/@sigstore/protobuf-specs": {
       "version": "0.1.0",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "Apache-2.0",
       "engines": {
@@ -13725,7 +13753,7 @@
     },
     "node_modules/npm/node_modules/@sigstore/tuf": {
       "version": "1.0.2",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -13738,7 +13766,7 @@
     },
     "node_modules/npm/node_modules/@tootallnate/once": {
       "version": "2.0.0",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -13747,7 +13775,7 @@
     },
     "node_modules/npm/node_modules/@tufjs/canonical-json": {
       "version": "1.0.0",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -13756,7 +13784,7 @@
     },
     "node_modules/npm/node_modules/@tufjs/models": {
       "version": "1.0.4",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -13769,7 +13797,7 @@
     },
     "node_modules/npm/node_modules/abbrev": {
       "version": "2.0.0",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
@@ -13778,7 +13806,7 @@
     },
     "node_modules/npm/node_modules/abort-controller": {
       "version": "3.0.0",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -13790,7 +13818,7 @@
     },
     "node_modules/npm/node_modules/agent-base": {
       "version": "6.0.2",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -13802,7 +13830,7 @@
     },
     "node_modules/npm/node_modules/agentkeepalive": {
       "version": "4.3.0",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -13816,7 +13844,7 @@
     },
     "node_modules/npm/node_modules/aggregate-error": {
       "version": "3.1.0",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -13829,7 +13857,7 @@
     },
     "node_modules/npm/node_modules/ansi-regex": {
       "version": "5.0.1",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -13838,7 +13866,7 @@
     },
     "node_modules/npm/node_modules/ansi-styles": {
       "version": "4.3.0",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -13853,19 +13881,19 @@
     },
     "node_modules/npm/node_modules/aproba": {
       "version": "2.0.0",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npm/node_modules/archy": {
       "version": "1.0.0",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/are-we-there-yet": {
       "version": "4.0.0",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -13878,13 +13906,13 @@
     },
     "node_modules/npm/node_modules/balanced-match": {
       "version": "1.0.2",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/base64-js": {
       "version": "1.5.1",
-      "dev": true,
+      "extraneous": true,
       "funding": [
         {
           "type": "github",
@@ -13904,7 +13932,7 @@
     },
     "node_modules/npm/node_modules/bin-links": {
       "version": "4.0.2",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -13919,7 +13947,7 @@
     },
     "node_modules/npm/node_modules/binary-extensions": {
       "version": "2.2.0",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -13928,7 +13956,7 @@
     },
     "node_modules/npm/node_modules/brace-expansion": {
       "version": "2.0.1",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -13937,7 +13965,7 @@
     },
     "node_modules/npm/node_modules/buffer": {
       "version": "6.0.3",
-      "dev": true,
+      "extraneous": true,
       "funding": [
         {
           "type": "github",
@@ -13961,7 +13989,7 @@
     },
     "node_modules/npm/node_modules/builtins": {
       "version": "5.0.1",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -13970,7 +13998,7 @@
     },
     "node_modules/npm/node_modules/cacache": {
       "version": "17.1.3",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -13993,7 +14021,7 @@
     },
     "node_modules/npm/node_modules/chalk": {
       "version": "5.3.0",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -14005,7 +14033,7 @@
     },
     "node_modules/npm/node_modules/chownr": {
       "version": "2.0.0",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
@@ -14014,7 +14042,7 @@
     },
     "node_modules/npm/node_modules/ci-info": {
       "version": "3.8.0",
-      "dev": true,
+      "extraneous": true,
       "funding": [
         {
           "type": "github",
@@ -14029,7 +14057,7 @@
     },
     "node_modules/npm/node_modules/cidr-regex": {
       "version": "3.1.1",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "BSD-2-Clause",
       "dependencies": {
@@ -14041,7 +14069,7 @@
     },
     "node_modules/npm/node_modules/clean-stack": {
       "version": "2.2.0",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -14050,7 +14078,7 @@
     },
     "node_modules/npm/node_modules/cli-columns": {
       "version": "4.0.0",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -14063,7 +14091,7 @@
     },
     "node_modules/npm/node_modules/cli-table3": {
       "version": "0.6.3",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -14078,7 +14106,7 @@
     },
     "node_modules/npm/node_modules/clone": {
       "version": "1.0.4",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -14087,7 +14115,7 @@
     },
     "node_modules/npm/node_modules/cmd-shim": {
       "version": "6.0.1",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
@@ -14096,7 +14124,7 @@
     },
     "node_modules/npm/node_modules/color-convert": {
       "version": "2.0.1",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -14108,13 +14136,13 @@
     },
     "node_modules/npm/node_modules/color-name": {
       "version": "1.1.4",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/color-support": {
       "version": "1.1.3",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "bin": {
@@ -14123,7 +14151,7 @@
     },
     "node_modules/npm/node_modules/columnify": {
       "version": "1.6.0",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -14136,25 +14164,25 @@
     },
     "node_modules/npm/node_modules/common-ancestor-path": {
       "version": "1.0.1",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npm/node_modules/concat-map": {
       "version": "0.0.1",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/console-control-strings": {
       "version": "1.1.0",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npm/node_modules/cross-spawn": {
       "version": "7.0.3",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -14168,7 +14196,7 @@
     },
     "node_modules/npm/node_modules/cross-spawn/node_modules/which": {
       "version": "2.0.2",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -14183,7 +14211,7 @@
     },
     "node_modules/npm/node_modules/cssesc": {
       "version": "3.0.0",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "bin": {
@@ -14195,7 +14223,7 @@
     },
     "node_modules/npm/node_modules/debug": {
       "version": "4.3.4",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -14212,13 +14240,13 @@
     },
     "node_modules/npm/node_modules/debug/node_modules/ms": {
       "version": "2.1.2",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/defaults": {
       "version": "1.0.4",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -14230,13 +14258,13 @@
     },
     "node_modules/npm/node_modules/delegates": {
       "version": "1.0.0",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/depd": {
       "version": "2.0.0",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -14245,7 +14273,7 @@
     },
     "node_modules/npm/node_modules/diff": {
       "version": "5.1.0",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "BSD-3-Clause",
       "engines": {
@@ -14254,29 +14282,28 @@
     },
     "node_modules/npm/node_modules/eastasianwidth": {
       "version": "0.2.0",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/emoji-regex": {
       "version": "8.0.0",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/encoding": {
       "version": "0.1.13",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "iconv-lite": "^0.6.2"
       }
     },
     "node_modules/npm/node_modules/env-paths": {
       "version": "2.2.1",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -14285,13 +14312,13 @@
     },
     "node_modules/npm/node_modules/err-code": {
       "version": "2.0.3",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/event-target-shim": {
       "version": "5.0.1",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -14300,7 +14327,7 @@
     },
     "node_modules/npm/node_modules/events": {
       "version": "3.3.0",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -14309,13 +14336,13 @@
     },
     "node_modules/npm/node_modules/exponential-backoff": {
       "version": "3.1.1",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "Apache-2.0"
     },
     "node_modules/npm/node_modules/fastest-levenshtein": {
       "version": "1.0.16",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -14324,7 +14351,7 @@
     },
     "node_modules/npm/node_modules/foreground-child": {
       "version": "3.1.1",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -14340,7 +14367,7 @@
     },
     "node_modules/npm/node_modules/fs-minipass": {
       "version": "3.0.2",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -14352,19 +14379,19 @@
     },
     "node_modules/npm/node_modules/fs.realpath": {
       "version": "1.0.0",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npm/node_modules/function-bind": {
       "version": "1.1.1",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/gauge": {
       "version": "5.0.1",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -14383,7 +14410,7 @@
     },
     "node_modules/npm/node_modules/glob": {
       "version": "10.2.7",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -14405,13 +14432,13 @@
     },
     "node_modules/npm/node_modules/graceful-fs": {
       "version": "4.2.11",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npm/node_modules/has": {
       "version": "1.0.3",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -14423,13 +14450,13 @@
     },
     "node_modules/npm/node_modules/has-unicode": {
       "version": "2.0.1",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npm/node_modules/hosted-git-info": {
       "version": "6.1.1",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -14441,13 +14468,13 @@
     },
     "node_modules/npm/node_modules/http-cache-semantics": {
       "version": "4.1.1",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "BSD-2-Clause"
     },
     "node_modules/npm/node_modules/http-proxy-agent": {
       "version": "5.0.0",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -14461,7 +14488,7 @@
     },
     "node_modules/npm/node_modules/https-proxy-agent": {
       "version": "5.0.1",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -14474,7 +14501,7 @@
     },
     "node_modules/npm/node_modules/humanize-ms": {
       "version": "1.2.1",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -14483,10 +14510,9 @@
     },
     "node_modules/npm/node_modules/iconv-lite": {
       "version": "0.6.3",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
       },
@@ -14496,7 +14522,7 @@
     },
     "node_modules/npm/node_modules/ieee754": {
       "version": "1.2.1",
-      "dev": true,
+      "extraneous": true,
       "funding": [
         {
           "type": "github",
@@ -14516,7 +14542,7 @@
     },
     "node_modules/npm/node_modules/ignore-walk": {
       "version": "6.0.3",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -14528,7 +14554,7 @@
     },
     "node_modules/npm/node_modules/imurmurhash": {
       "version": "0.1.4",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -14537,7 +14563,7 @@
     },
     "node_modules/npm/node_modules/indent-string": {
       "version": "4.0.0",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -14546,7 +14572,7 @@
     },
     "node_modules/npm/node_modules/inflight": {
       "version": "1.0.6",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -14556,13 +14582,13 @@
     },
     "node_modules/npm/node_modules/inherits": {
       "version": "2.0.4",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npm/node_modules/ini": {
       "version": "4.1.1",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
@@ -14571,7 +14597,7 @@
     },
     "node_modules/npm/node_modules/init-package-json": {
       "version": "5.0.0",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -14589,13 +14615,13 @@
     },
     "node_modules/npm/node_modules/ip": {
       "version": "2.0.0",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/ip-regex": {
       "version": "4.3.0",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -14604,7 +14630,7 @@
     },
     "node_modules/npm/node_modules/is-cidr": {
       "version": "4.0.2",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "BSD-2-Clause",
       "dependencies": {
@@ -14616,7 +14642,7 @@
     },
     "node_modules/npm/node_modules/is-core-module": {
       "version": "2.12.1",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -14628,7 +14654,7 @@
     },
     "node_modules/npm/node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -14637,19 +14663,19 @@
     },
     "node_modules/npm/node_modules/is-lambda": {
       "version": "1.0.1",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/isexe": {
       "version": "2.0.0",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npm/node_modules/jackspeak": {
       "version": "2.2.1",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
@@ -14667,7 +14693,7 @@
     },
     "node_modules/npm/node_modules/json-parse-even-better-errors": {
       "version": "3.0.0",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -14676,7 +14702,7 @@
     },
     "node_modules/npm/node_modules/json-stringify-nice": {
       "version": "1.1.4",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "funding": {
@@ -14685,28 +14711,28 @@
     },
     "node_modules/npm/node_modules/jsonparse": {
       "version": "1.3.1",
-      "dev": true,
       "engines": [
         "node >= 0.2.0"
       ],
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/just-diff": {
       "version": "6.0.2",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/just-diff-apply": {
       "version": "5.5.0",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/libnpmaccess": {
       "version": "7.0.2",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -14719,7 +14745,7 @@
     },
     "node_modules/npm/node_modules/libnpmdiff": {
       "version": "5.0.19",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -14739,7 +14765,7 @@
     },
     "node_modules/npm/node_modules/libnpmexec": {
       "version": "6.0.3",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -14761,7 +14787,7 @@
     },
     "node_modules/npm/node_modules/libnpmfund": {
       "version": "4.0.19",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -14773,7 +14799,7 @@
     },
     "node_modules/npm/node_modules/libnpmhook": {
       "version": "9.0.3",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -14786,7 +14812,7 @@
     },
     "node_modules/npm/node_modules/libnpmorg": {
       "version": "5.0.4",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -14799,7 +14825,7 @@
     },
     "node_modules/npm/node_modules/libnpmpack": {
       "version": "5.0.19",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -14814,7 +14840,7 @@
     },
     "node_modules/npm/node_modules/libnpmpublish": {
       "version": "7.5.0",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -14833,7 +14859,7 @@
     },
     "node_modules/npm/node_modules/libnpmsearch": {
       "version": "6.0.2",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -14845,7 +14871,7 @@
     },
     "node_modules/npm/node_modules/libnpmteam": {
       "version": "5.0.3",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -14858,7 +14884,7 @@
     },
     "node_modules/npm/node_modules/libnpmversion": {
       "version": "4.0.2",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -14874,7 +14900,7 @@
     },
     "node_modules/npm/node_modules/lru-cache": {
       "version": "7.18.3",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
@@ -14883,7 +14909,7 @@
     },
     "node_modules/npm/node_modules/make-fetch-happen": {
       "version": "11.1.1",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -14909,7 +14935,7 @@
     },
     "node_modules/npm/node_modules/minimatch": {
       "version": "9.0.3",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -14924,7 +14950,7 @@
     },
     "node_modules/npm/node_modules/minipass": {
       "version": "5.0.0",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
@@ -14933,7 +14959,7 @@
     },
     "node_modules/npm/node_modules/minipass-collect": {
       "version": "1.0.2",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -14945,7 +14971,7 @@
     },
     "node_modules/npm/node_modules/minipass-collect/node_modules/minipass": {
       "version": "3.3.6",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -14957,7 +14983,7 @@
     },
     "node_modules/npm/node_modules/minipass-fetch": {
       "version": "3.0.3",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -14974,7 +15000,7 @@
     },
     "node_modules/npm/node_modules/minipass-flush": {
       "version": "1.0.5",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -14986,7 +15012,7 @@
     },
     "node_modules/npm/node_modules/minipass-flush/node_modules/minipass": {
       "version": "3.3.6",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -14998,7 +15024,7 @@
     },
     "node_modules/npm/node_modules/minipass-json-stream": {
       "version": "1.0.1",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -15008,7 +15034,7 @@
     },
     "node_modules/npm/node_modules/minipass-json-stream/node_modules/minipass": {
       "version": "3.3.6",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -15020,7 +15046,7 @@
     },
     "node_modules/npm/node_modules/minipass-pipeline": {
       "version": "1.2.4",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -15032,7 +15058,7 @@
     },
     "node_modules/npm/node_modules/minipass-pipeline/node_modules/minipass": {
       "version": "3.3.6",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -15044,7 +15070,7 @@
     },
     "node_modules/npm/node_modules/minipass-sized": {
       "version": "1.0.3",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -15056,7 +15082,7 @@
     },
     "node_modules/npm/node_modules/minipass-sized/node_modules/minipass": {
       "version": "3.3.6",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -15068,7 +15094,7 @@
     },
     "node_modules/npm/node_modules/minizlib": {
       "version": "2.1.2",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -15081,7 +15107,7 @@
     },
     "node_modules/npm/node_modules/minizlib/node_modules/minipass": {
       "version": "3.3.6",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -15093,7 +15119,7 @@
     },
     "node_modules/npm/node_modules/mkdirp": {
       "version": "1.0.4",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "bin": {
@@ -15105,13 +15131,13 @@
     },
     "node_modules/npm/node_modules/ms": {
       "version": "2.1.3",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/mute-stream": {
       "version": "1.0.0",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
@@ -15120,7 +15146,7 @@
     },
     "node_modules/npm/node_modules/negotiator": {
       "version": "0.6.3",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -15129,7 +15155,7 @@
     },
     "node_modules/npm/node_modules/node-gyp": {
       "version": "9.4.0",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -15154,13 +15180,13 @@
     },
     "node_modules/npm/node_modules/node-gyp/node_modules/abbrev": {
       "version": "1.1.1",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npm/node_modules/node-gyp/node_modules/are-we-there-yet": {
       "version": "3.0.1",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -15173,7 +15199,7 @@
     },
     "node_modules/npm/node_modules/node-gyp/node_modules/brace-expansion": {
       "version": "1.1.11",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -15183,7 +15209,7 @@
     },
     "node_modules/npm/node_modules/node-gyp/node_modules/gauge": {
       "version": "4.0.4",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -15202,7 +15228,7 @@
     },
     "node_modules/npm/node_modules/node-gyp/node_modules/glob": {
       "version": "7.2.3",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -15222,7 +15248,7 @@
     },
     "node_modules/npm/node_modules/node-gyp/node_modules/minimatch": {
       "version": "3.1.2",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -15234,7 +15260,7 @@
     },
     "node_modules/npm/node_modules/node-gyp/node_modules/nopt": {
       "version": "6.0.0",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -15249,7 +15275,7 @@
     },
     "node_modules/npm/node_modules/node-gyp/node_modules/npmlog": {
       "version": "6.0.2",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -15264,7 +15290,7 @@
     },
     "node_modules/npm/node_modules/node-gyp/node_modules/readable-stream": {
       "version": "3.6.2",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -15278,13 +15304,13 @@
     },
     "node_modules/npm/node_modules/node-gyp/node_modules/signal-exit": {
       "version": "3.0.7",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npm/node_modules/node-gyp/node_modules/which": {
       "version": "2.0.2",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -15299,7 +15325,7 @@
     },
     "node_modules/npm/node_modules/nopt": {
       "version": "7.2.0",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -15314,7 +15340,7 @@
     },
     "node_modules/npm/node_modules/normalize-package-data": {
       "version": "5.0.0",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "BSD-2-Clause",
       "dependencies": {
@@ -15329,7 +15355,7 @@
     },
     "node_modules/npm/node_modules/npm-audit-report": {
       "version": "5.0.0",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
@@ -15338,7 +15364,7 @@
     },
     "node_modules/npm/node_modules/npm-bundled": {
       "version": "3.0.0",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -15350,7 +15376,7 @@
     },
     "node_modules/npm/node_modules/npm-install-checks": {
       "version": "6.1.1",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "BSD-2-Clause",
       "dependencies": {
@@ -15362,7 +15388,7 @@
     },
     "node_modules/npm/node_modules/npm-normalize-package-bin": {
       "version": "3.0.1",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
@@ -15371,7 +15397,7 @@
     },
     "node_modules/npm/node_modules/npm-package-arg": {
       "version": "10.1.0",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -15386,7 +15412,7 @@
     },
     "node_modules/npm/node_modules/npm-packlist": {
       "version": "7.0.4",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -15398,7 +15424,7 @@
     },
     "node_modules/npm/node_modules/npm-pick-manifest": {
       "version": "8.0.1",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -15413,7 +15439,7 @@
     },
     "node_modules/npm/node_modules/npm-profile": {
       "version": "7.0.1",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -15426,7 +15452,7 @@
     },
     "node_modules/npm/node_modules/npm-registry-fetch": {
       "version": "14.0.5",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -15444,7 +15470,7 @@
     },
     "node_modules/npm/node_modules/npm-user-validate": {
       "version": "2.0.0",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "BSD-2-Clause",
       "engines": {
@@ -15453,7 +15479,7 @@
     },
     "node_modules/npm/node_modules/npmlog": {
       "version": "7.0.1",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -15468,7 +15494,7 @@
     },
     "node_modules/npm/node_modules/once": {
       "version": "1.4.0",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -15477,7 +15503,7 @@
     },
     "node_modules/npm/node_modules/p-map": {
       "version": "4.0.0",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -15492,7 +15518,7 @@
     },
     "node_modules/npm/node_modules/pacote": {
       "version": "15.2.0",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -15524,7 +15550,7 @@
     },
     "node_modules/npm/node_modules/parse-conflict-json": {
       "version": "3.0.1",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -15538,7 +15564,7 @@
     },
     "node_modules/npm/node_modules/path-is-absolute": {
       "version": "1.0.1",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -15547,7 +15573,7 @@
     },
     "node_modules/npm/node_modules/path-key": {
       "version": "3.1.1",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -15556,7 +15582,7 @@
     },
     "node_modules/npm/node_modules/path-scurry": {
       "version": "1.9.2",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
@@ -15572,7 +15598,7 @@
     },
     "node_modules/npm/node_modules/path-scurry/node_modules/lru-cache": {
       "version": "9.1.1",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
@@ -15581,7 +15607,7 @@
     },
     "node_modules/npm/node_modules/postcss-selector-parser": {
       "version": "6.0.13",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -15594,7 +15620,7 @@
     },
     "node_modules/npm/node_modules/proc-log": {
       "version": "3.0.0",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
@@ -15603,7 +15629,7 @@
     },
     "node_modules/npm/node_modules/process": {
       "version": "0.11.10",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -15612,7 +15638,7 @@
     },
     "node_modules/npm/node_modules/promise-all-reject-late": {
       "version": "1.0.1",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "funding": {
@@ -15621,7 +15647,7 @@
     },
     "node_modules/npm/node_modules/promise-call-limit": {
       "version": "1.0.2",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "funding": {
@@ -15630,13 +15656,13 @@
     },
     "node_modules/npm/node_modules/promise-inflight": {
       "version": "1.0.1",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npm/node_modules/promise-retry": {
       "version": "2.0.1",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -15649,7 +15675,7 @@
     },
     "node_modules/npm/node_modules/promzard": {
       "version": "1.0.0",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -15661,7 +15687,7 @@
     },
     "node_modules/npm/node_modules/qrcode-terminal": {
       "version": "0.12.0",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "bin": {
         "qrcode-terminal": "bin/qrcode-terminal.js"
@@ -15669,7 +15695,7 @@
     },
     "node_modules/npm/node_modules/read": {
       "version": "2.1.0",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -15681,7 +15707,7 @@
     },
     "node_modules/npm/node_modules/read-cmd-shim": {
       "version": "4.0.0",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
@@ -15690,7 +15716,7 @@
     },
     "node_modules/npm/node_modules/read-package-json": {
       "version": "6.0.4",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -15705,7 +15731,7 @@
     },
     "node_modules/npm/node_modules/read-package-json-fast": {
       "version": "3.0.2",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -15718,7 +15744,7 @@
     },
     "node_modules/npm/node_modules/readable-stream": {
       "version": "4.4.0",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -15733,7 +15759,7 @@
     },
     "node_modules/npm/node_modules/retry": {
       "version": "0.12.0",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -15742,7 +15768,7 @@
     },
     "node_modules/npm/node_modules/rimraf": {
       "version": "3.0.2",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -15757,7 +15783,7 @@
     },
     "node_modules/npm/node_modules/rimraf/node_modules/brace-expansion": {
       "version": "1.1.11",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -15767,7 +15793,7 @@
     },
     "node_modules/npm/node_modules/rimraf/node_modules/glob": {
       "version": "7.2.3",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -15787,7 +15813,7 @@
     },
     "node_modules/npm/node_modules/rimraf/node_modules/minimatch": {
       "version": "3.1.2",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -15799,7 +15825,7 @@
     },
     "node_modules/npm/node_modules/safe-buffer": {
       "version": "5.2.1",
-      "dev": true,
+      "extraneous": true,
       "funding": [
         {
           "type": "github",
@@ -15819,14 +15845,13 @@
     },
     "node_modules/npm/node_modules/safer-buffer": {
       "version": "2.1.2",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/npm/node_modules/semver": {
       "version": "7.5.4",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -15841,7 +15866,7 @@
     },
     "node_modules/npm/node_modules/semver/node_modules/lru-cache": {
       "version": "6.0.0",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -15853,13 +15878,13 @@
     },
     "node_modules/npm/node_modules/set-blocking": {
       "version": "2.0.0",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npm/node_modules/shebang-command": {
       "version": "2.0.0",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -15871,7 +15896,7 @@
     },
     "node_modules/npm/node_modules/shebang-regex": {
       "version": "3.0.0",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -15880,7 +15905,7 @@
     },
     "node_modules/npm/node_modules/signal-exit": {
       "version": "4.0.2",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
@@ -15892,7 +15917,7 @@
     },
     "node_modules/npm/node_modules/sigstore": {
       "version": "1.7.0",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -15909,7 +15934,7 @@
     },
     "node_modules/npm/node_modules/smart-buffer": {
       "version": "4.2.0",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -15919,7 +15944,7 @@
     },
     "node_modules/npm/node_modules/socks": {
       "version": "2.7.1",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -15933,7 +15958,7 @@
     },
     "node_modules/npm/node_modules/socks-proxy-agent": {
       "version": "7.0.0",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -15947,7 +15972,7 @@
     },
     "node_modules/npm/node_modules/spdx-correct": {
       "version": "3.2.0",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -15957,13 +15982,13 @@
     },
     "node_modules/npm/node_modules/spdx-exceptions": {
       "version": "2.3.0",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "CC-BY-3.0"
     },
     "node_modules/npm/node_modules/spdx-expression-parse": {
       "version": "3.0.1",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -15973,13 +15998,13 @@
     },
     "node_modules/npm/node_modules/spdx-license-ids": {
       "version": "3.0.13",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "CC0-1.0"
     },
     "node_modules/npm/node_modules/ssri": {
       "version": "10.0.4",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -15991,7 +16016,7 @@
     },
     "node_modules/npm/node_modules/string_decoder": {
       "version": "1.3.0",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -16000,7 +16025,7 @@
     },
     "node_modules/npm/node_modules/string-width": {
       "version": "4.2.3",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -16015,7 +16040,7 @@
     "node_modules/npm/node_modules/string-width-cjs": {
       "name": "string-width",
       "version": "4.2.3",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -16029,7 +16054,7 @@
     },
     "node_modules/npm/node_modules/strip-ansi": {
       "version": "6.0.1",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -16042,7 +16067,7 @@
     "node_modules/npm/node_modules/strip-ansi-cjs": {
       "name": "strip-ansi",
       "version": "6.0.1",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -16054,7 +16079,7 @@
     },
     "node_modules/npm/node_modules/supports-color": {
       "version": "9.4.0",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -16066,7 +16091,7 @@
     },
     "node_modules/npm/node_modules/tar": {
       "version": "6.1.15",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -16083,7 +16108,7 @@
     },
     "node_modules/npm/node_modules/tar/node_modules/fs-minipass": {
       "version": "2.1.0",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -16095,7 +16120,7 @@
     },
     "node_modules/npm/node_modules/tar/node_modules/fs-minipass/node_modules/minipass": {
       "version": "3.3.6",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -16107,19 +16132,19 @@
     },
     "node_modules/npm/node_modules/text-table": {
       "version": "0.2.0",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/tiny-relative-date": {
       "version": "1.3.0",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/treeverse": {
       "version": "3.0.0",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
@@ -16128,7 +16153,7 @@
     },
     "node_modules/npm/node_modules/tuf-js": {
       "version": "1.1.7",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -16142,7 +16167,7 @@
     },
     "node_modules/npm/node_modules/unique-filename": {
       "version": "3.0.0",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -16154,7 +16179,7 @@
     },
     "node_modules/npm/node_modules/unique-slug": {
       "version": "4.0.0",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -16166,13 +16191,13 @@
     },
     "node_modules/npm/node_modules/util-deprecate": {
       "version": "1.0.2",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/validate-npm-package-license": {
       "version": "3.0.4",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -16182,7 +16207,7 @@
     },
     "node_modules/npm/node_modules/validate-npm-package-name": {
       "version": "5.0.0",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -16194,13 +16219,13 @@
     },
     "node_modules/npm/node_modules/walk-up-path": {
       "version": "3.0.1",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npm/node_modules/wcwidth": {
       "version": "1.0.1",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -16209,7 +16234,7 @@
     },
     "node_modules/npm/node_modules/which": {
       "version": "3.0.1",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -16224,7 +16249,7 @@
     },
     "node_modules/npm/node_modules/wide-align": {
       "version": "1.1.5",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -16233,7 +16258,7 @@
     },
     "node_modules/npm/node_modules/wrap-ansi": {
       "version": "8.1.0",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -16251,7 +16276,7 @@
     "node_modules/npm/node_modules/wrap-ansi-cjs": {
       "name": "wrap-ansi",
       "version": "7.0.0",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -16268,7 +16293,7 @@
     },
     "node_modules/npm/node_modules/wrap-ansi/node_modules/ansi-regex": {
       "version": "6.0.1",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -16280,7 +16305,7 @@
     },
     "node_modules/npm/node_modules/wrap-ansi/node_modules/ansi-styles": {
       "version": "6.2.1",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -16292,13 +16317,13 @@
     },
     "node_modules/npm/node_modules/wrap-ansi/node_modules/emoji-regex": {
       "version": "9.2.2",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/wrap-ansi/node_modules/string-width": {
       "version": "5.1.2",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -16315,7 +16340,7 @@
     },
     "node_modules/npm/node_modules/wrap-ansi/node_modules/strip-ansi": {
       "version": "7.1.0",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -16330,13 +16355,13 @@
     },
     "node_modules/npm/node_modules/wrappy": {
       "version": "1.0.2",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npm/node_modules/write-file-atomic": {
       "version": "5.0.1",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -16349,7 +16374,7 @@
     },
     "node_modules/npm/node_modules/yallist": {
       "version": "4.0.0",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC"
     },
@@ -17546,7 +17571,6 @@
       "version": "18.2.0",
       "resolved": "https://registry.npmjs.org/react/-/react-18.2.0.tgz",
       "integrity": "sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==",
-      "dev": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -17566,7 +17590,6 @@
       "version": "18.2.0",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.2.0.tgz",
       "integrity": "sha512-6IMTriUmvsjHUjNtEDudZfuDQUoWXVxKHhlEGSk81n4YFS+r/Kl99wXiwlVXtPBtJenozv2P+hxDsw9eA7Xo6g==",
-      "dev": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.0"
@@ -18505,7 +18528,6 @@
       "version": "0.23.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.0.tgz",
       "integrity": "sha512-CtuThmgHNg7zIZWAXi3AsyIzA3n4xx7aNyjwC2VJldO2LMVDhFK+63xGqq6CsJH4rTAt6/M+N4GhZiDYPx9eUw==",
-      "dev": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       }
@@ -21248,6 +21270,23 @@
       "dev": true,
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/yjs": {
+      "version": "13.6.8",
+      "resolved": "https://registry.npmjs.org/yjs/-/yjs-13.6.8.tgz",
+      "integrity": "sha512-ZPq0hpJQb6f59B++Ngg4cKexDJTvfOgeiv0sBc4sUm8CaBWH7OQC4kcCgrqbjJ/B2+6vO49exvTmYfdlPtcjbg==",
+      "peer": true,
+      "dependencies": {
+        "lib0": "^0.2.74"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=8.0.0"
+      },
+      "funding": {
+        "type": "GitHub Sponsors ❤",
+        "url": "https://github.com/sponsors/dmonad"
       }
     },
     "node_modules/ylru": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,6 +32,7 @@
         "@radix-ui/react-toolbar": "^1.0.4",
         "@radix-ui/react-tooltip": "^1.0.6",
         "classnames": "^2.3.2",
+        "cm6-theme-basic-dark": "^0.2.0",
         "cm6-theme-basic-light": "^0.2.0",
         "codemirror": "^6.0.1",
         "downshift": "^7.6.0",
@@ -6394,6 +6395,17 @@
       "dev": true,
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/cm6-theme-basic-dark": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/cm6-theme-basic-dark/-/cm6-theme-basic-dark-0.2.0.tgz",
+      "integrity": "sha512-+mNNJecRtxS/KkloMDCQF0oTrT6aFGRZTjnBcdT5UG1pcDO4Brq8l1+0KR/8dZ7hub2gOGOzoi3rGFD8GzlH7Q==",
+      "peerDependencies": {
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.0.0",
+        "@lezer/highlight": "^1.0.0"
       }
     },
     "node_modules/cm6-theme-basic-light": {

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "@radix-ui/react-toolbar": "^1.0.4",
     "@radix-ui/react-tooltip": "^1.0.6",
     "classnames": "^2.3.2",
+    "cm6-theme-basic-dark": "^0.2.0",
     "cm6-theme-basic-light": "^0.2.0",
     "codemirror": "^6.0.1",
     "downshift": "^7.6.0",

--- a/src/MDXEditor.tsx
+++ b/src/MDXEditor.tsx
@@ -226,6 +226,7 @@ export const MDXEditor = React.forwardRef<MDXEditorMethods, MDXEditorProps>((pro
     <RealmPluginInitializer
       plugins={[
         corePlugin({
+          className: props.className ?? '',
           contentEditableClassName: props.contentEditableClassName ?? '',
           initialMarkdown: props.markdown,
           onChange: props.onChange ?? noop,

--- a/src/examples/toolbar.tsx
+++ b/src/examples/toolbar.tsx
@@ -1,7 +1,17 @@
+import { Extension } from '@codemirror/state'
+import type { Story } from '@ladle/react'
+import { basicDark } from 'cm6-theme-basic-dark'
 import React from 'react'
 import {
   AdmonitionDirectiveDescriptor,
+  BlockTypeSelect,
+  BoldItalicUnderlineToggles,
+  CreateLink,
+  DiffSourceToggleWrapper,
+  InsertImage,
+  ListsToggle,
   MDXEditor,
+  Separator,
   UndoRedo,
   codeBlockPlugin,
   codeMirrorPlugin,
@@ -18,19 +28,11 @@ import {
   sandpackPlugin,
   tablePlugin,
   thematicBreakPlugin,
-  toolbarPlugin,
-  Separator,
-  BlockTypeSelect,
-  BoldItalicUnderlineToggles,
-  CreateLink,
-  DiffSourceToggleWrapper,
-  InsertImage,
-  ListsToggle
+  toolbarPlugin
 } from '..'
 import { ALL_PLUGINS, YoutubeDirectiveDescriptor, virtuosoSampleSandpackConfig } from './_boilerplate'
 import kitchenSinkMarkdown from './assets/kitchen-sink.md?raw'
 import './dark-editor.css'
-import type { Story } from '@ladle/react'
 
 export const Basics = () => {
   return <MDXEditor markdown={kitchenSinkMarkdown} plugins={ALL_PLUGINS} />
@@ -56,7 +58,7 @@ export const CustomTheming = () => {
 export const DarkTheme = () => {
   return (
     <MDXEditor
-      className="dark-theme dark-editor"
+      className="dark-theme"
       markdown={'hello world'}
       plugins={[
         toolbarPlugin({
@@ -85,7 +87,7 @@ export const DarkTheme = () => {
         thematicBreakPlugin(),
         frontmatterPlugin(),
         directivesPlugin({ directiveDescriptors: [YoutubeDirectiveDescriptor, AdmonitionDirectiveDescriptor] }),
-        diffSourcePlugin({ viewMode: 'rich-text', diffMarkdown: 'boo' }),
+        diffSourcePlugin({ viewMode: 'rich-text', diffMarkdown: 'BOO', theme: basicDark as Extension }),
         markdownShortcutPlugin()
       ]}
     />

--- a/src/examples/toolbar.tsx
+++ b/src/examples/toolbar.tsx
@@ -53,6 +53,45 @@ export const CustomTheming = () => {
   return <MDXEditor className="dark-theme dark-editor" markdown={kitchenSinkMarkdown} plugins={ALL_PLUGINS} />
 }
 
+export const DarkTheme = () => {
+  return (
+    <MDXEditor
+      className="dark-theme dark-editor"
+      markdown={'hello world'}
+      plugins={[
+        toolbarPlugin({
+          toolbarContents: () => (
+            <>
+              <DiffSourceToggleWrapper>
+                <UndoRedo />
+                <BoldItalicUnderlineToggles />
+                <ListsToggle />
+                <Separator />
+                <BlockTypeSelect />
+                <CreateLink />
+                <InsertImage />
+                <Separator />
+              </DiffSourceToggleWrapper>
+            </>
+          )
+        }),
+        listsPlugin(),
+        quotePlugin(),
+        headingsPlugin(),
+        linkPlugin(),
+        linkDialogPlugin(),
+        imagePlugin(),
+        tablePlugin(),
+        thematicBreakPlugin(),
+        frontmatterPlugin(),
+        directivesPlugin({ directiveDescriptors: [YoutubeDirectiveDescriptor, AdmonitionDirectiveDescriptor] }),
+        diffSourcePlugin({ viewMode: 'rich-text', diffMarkdown: 'boo' }),
+        markdownShortcutPlugin()
+      ]}
+    />
+  )
+}
+
 export const ConditionalToolbar = () => {
   return (
     <MDXEditor

--- a/src/plugins/core/index.ts
+++ b/src/plugins/core/index.ts
@@ -92,6 +92,7 @@ export const coreSystem = system((r) => {
 
   const rootEditor = r.node<LexicalEditor | null>(null)
   const activeEditor = r.node<LexicalEditor | null>(null, true)
+  const className = r.node<string>('')
   const contentEditableClassName = r.node<string>('')
   const readOnly = r.node<boolean>(false)
   const placeholder = r.node<React.ReactNode>('')
@@ -471,6 +472,7 @@ export const coreSystem = system((r) => {
 
     // DOM
     editorRootElementRef,
+    className,
     contentEditableClassName,
     placeholder,
     autoFocus,
@@ -505,6 +507,7 @@ export const coreSystem = system((r) => {
 
 interface CorePluginParams {
   initialMarkdown: string
+  className: string
   contentEditableClassName: string
   placeholder?: React.ReactNode
   autoFocus: boolean | { defaultSelection?: 'rootStart' | 'rootEnd'; preventScroll?: boolean | undefined }
@@ -525,6 +528,7 @@ export const [
 
   applyParamsToSystem(realm, params: CorePluginParams) {
     realm.pubKeys({
+      className: params.className,
       contentEditableClassName: params.contentEditableClassName,
       toMarkdownOptions: params.toMarkdownOptions,
       autoFocus: params.autoFocus,

--- a/src/plugins/diff-source/SourceEditor.tsx
+++ b/src/plugins/diff-source/SourceEditor.tsx
@@ -2,7 +2,6 @@ import { markdown as markdownLanguageSupport } from '@codemirror/lang-markdown'
 import { EditorState, Extension } from '@codemirror/state'
 import { EditorView, lineNumbers } from '@codemirror/view'
 import { basicLight } from 'cm6-theme-basic-light'
-import { basicDark } from 'cm6-theme-basic-dark'
 import { basicSetup } from 'codemirror'
 import React from 'react'
 import { diffSourcePluginHooks } from '.'
@@ -11,8 +10,9 @@ import { corePluginHooks } from '../core'
 export const COMMON_STATE_CONFIG_EXTENSIONS: Extension[] = [basicSetup, markdownLanguageSupport(), lineNumbers()]
 
 export const SourceEditor = () => {
-  const [markdown, readOnly, className] = corePluginHooks.useEmitterValues('markdown', 'readOnly', 'className')
+  const [markdown, readOnly] = corePluginHooks.useEmitterValues('markdown', 'readOnly')
   const updateMarkdown = diffSourcePluginHooks.usePublisher('markdownSourceEditorValue')
+  const [theme] = diffSourcePluginHooks.useEmitterValues('theme', 'viewMode')
   const editorViewRef = React.useRef<EditorView | null>(null)
 
   const ref = React.useCallback(
@@ -24,8 +24,8 @@ export const SourceEditor = () => {
             updateMarkdown(state.doc.toString())
           })
         ]
-        if (className && className.indexOf('dark-theme') > -1) {
-          extensions.push(basicDark)
+        if (theme) {
+          extensions.push(theme)
         } else {
           extensions.push(basicLight)
         }
@@ -42,7 +42,7 @@ export const SourceEditor = () => {
         editorViewRef.current = null
       }
     },
-    [className, markdown, readOnly, updateMarkdown]
+    [markdown, readOnly, theme, updateMarkdown]
   )
 
   return <div ref={ref} className="cm-sourceView" />

--- a/src/plugins/diff-source/SourceEditor.tsx
+++ b/src/plugins/diff-source/SourceEditor.tsx
@@ -2,15 +2,16 @@ import { markdown as markdownLanguageSupport } from '@codemirror/lang-markdown'
 import { EditorState, Extension } from '@codemirror/state'
 import { EditorView, lineNumbers } from '@codemirror/view'
 import { basicLight } from 'cm6-theme-basic-light'
+import { basicDark } from 'cm6-theme-basic-dark'
 import { basicSetup } from 'codemirror'
 import React from 'react'
 import { diffSourcePluginHooks } from '.'
 import { corePluginHooks } from '../core'
 
-export const COMMON_STATE_CONFIG_EXTENSIONS: Extension[] = [basicSetup, basicLight, markdownLanguageSupport(), lineNumbers()]
+export const COMMON_STATE_CONFIG_EXTENSIONS: Extension[] = [basicSetup, markdownLanguageSupport(), lineNumbers()]
 
 export const SourceEditor = () => {
-  const [markdown, readOnly] = corePluginHooks.useEmitterValues('markdown', 'readOnly')
+  const [markdown, readOnly, className] = corePluginHooks.useEmitterValues('markdown', 'readOnly', 'className')
   const updateMarkdown = diffSourcePluginHooks.usePublisher('markdownSourceEditorValue')
   const editorViewRef = React.useRef<EditorView | null>(null)
 
@@ -23,6 +24,11 @@ export const SourceEditor = () => {
             updateMarkdown(state.doc.toString())
           })
         ]
+        if (className && className.indexOf('dark-theme') > -1) {
+          extensions.push(basicDark)
+        } else {
+          extensions.push(basicLight)
+        }
         if (readOnly) {
           extensions.push(EditorState.readOnly.of(true))
         }
@@ -36,7 +42,7 @@ export const SourceEditor = () => {
         editorViewRef.current = null
       }
     },
-    [markdown, readOnly, updateMarkdown]
+    [className, markdown, readOnly, updateMarkdown]
   )
 
   return <div ref={ref} className="cm-sourceView" />

--- a/src/plugins/diff-source/index.tsx
+++ b/src/plugins/diff-source/index.tsx
@@ -1,3 +1,4 @@
+import { Extension } from '@codemirror/state'
 import { realmPlugin, system } from '../../gurx'
 import { coreSystem } from '../core'
 import { DiffSourceWrapper } from './DiffSourceWrapper'
@@ -9,6 +10,7 @@ export type ViewMode = 'rich-text' | 'source' | 'diff'
 export const diffSourceSystem = system(
   (r, [{ markdown, setMarkdown }]) => {
     const diffMarkdown = r.node('')
+    const theme = r.node<Extension | null>(null)
     const markdownSourceEditorValue = r.node('')
 
     r.link(markdown, markdownSourceEditorValue)
@@ -34,7 +36,7 @@ export const diffSourceSystem = system(
         }
       }
     )
-    return { viewMode, diffMarkdown, markdownSourceEditorValue }
+    return { viewMode, diffMarkdown, markdownSourceEditorValue, theme }
   },
   [coreSystem]
 )
@@ -48,8 +50,11 @@ export const [
   id: 'diff-source',
   systemSpec: diffSourceSystem,
 
-  applyParamsToSystem(r, params?: { viewMode?: ViewMode; diffMarkdown?: string }) {
-    r.pubKey('viewMode', params?.viewMode || 'rich-text')
+  applyParamsToSystem(realm, params?: { viewMode?: ViewMode; diffMarkdown?: string; theme?: Extension }) {
+    realm.pubKeys({
+      viewMode: params?.viewMode,
+      theme: params?.theme
+    })
   },
   init(r, params) {
     r.pubKey('diffMarkdown', params?.diffMarkdown || '')

--- a/src/styles/ui.module.css
+++ b/src/styles/ui.module.css
@@ -144,7 +144,7 @@
   display: flex;
   flex-direction: row;
   gap: var(--spacing-1);
-  border-radius: var(--radius-medium);
+  border-radius: var(--radius-medium) var(--radius-medium) 0 0;
   padding: var(--spacing-2) var(--spacing-2);
   align-items: center;
   overflow-x: auto;


### PR DESCRIPTION
As the comment says from @petyosi, I added the extensions in props. However, I am unable to satisfy TypeScript, which is strange. I need help. [Here is the link](https://github.com/mdx-editor/editor/pull/124#issuecomment-1764315258) for reference.

By the way, can I remove the dark theme from the dependencies? We don't want to include it in the bundle. But can we still have the demo? Also, do I need to update the documentation? Thank you.