### PR TITLE
feat: Add check list type in the `list` plugin

### DIFF
--- a/docs/basic-formatting.md
+++ b/docs/basic-formatting.md
@@ -38,7 +38,7 @@ const markdown = "> This is a quote"
 
 ## Lists
 
-The Lists plugin enables the usage of ordered and unordered lists, including multiple levels of nesting.
+The Lists plugin enables the usage of ordered, unordered and check lists, including multiple levels of nesting.
 
 ```tsx
 

--- a/docs/live-demo-contents.md
+++ b/docs/live-demo-contents.md
@@ -14,6 +14,7 @@ In here, you can find the following markdown elements:
 * Lists
   * Unordered
   * Ordered
+  * Check lists
   * And nested ;)
 * Links
 * Bold/Italic/Underline formatting

--- a/package-lock.json
+++ b/package-lock.json
@@ -44,6 +44,7 @@
         "mdast-util-from-markdown": "^1.3.0",
         "mdast-util-frontmatter": "1.0.1",
         "mdast-util-gfm-table": "^1.0.7",
+        "mdast-util-gfm-task-list-item": "1.0.2",
         "mdast-util-mdx": "2.0.1",
         "mdast-util-mdx-jsx": "^2.1.4",
         "mdast-util-to-hast": "^12.3.0",
@@ -51,6 +52,7 @@
         "micromark-extension-directive": "2.2.0",
         "micromark-extension-frontmatter": "1.1.0",
         "micromark-extension-gfm-table": "^1.0.6",
+        "micromark-extension-gfm-task-list-item": "1.0.5",
         "micromark-extension-mdxjs": "1.0.1",
         "react-hook-form": "^7.44.2",
         "unidiff": "^1.0.2"
@@ -11793,7 +11795,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/mdast-util-gfm-task-list-item/-/mdast-util-gfm-task-list-item-1.0.2.tgz",
       "integrity": "sha512-PFTA1gzfp1B1UaiJVyhJZA1rm0+Tzn690frc/L8vNX1Jop4STZgOE6bxUhnzdVSB+vm2GU1tIsuQcA9bxTQpMQ==",
-      "dev": true,
       "dependencies": {
         "@types/mdast": "^3.0.0",
         "mdast-util-to-markdown": "^1.3.0"
@@ -12355,7 +12356,6 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/micromark-extension-gfm-task-list-item/-/micromark-extension-gfm-task-list-item-1.0.5.tgz",
       "integrity": "sha512-RMFXl2uQ0pNQy6Lun2YBYT9g9INXtWJULgbt01D/x8/6yJ2qpKyzdZD3pi6UIkzF++Da49xAelVKUeUMqd5eIQ==",
-      "dev": true,
       "dependencies": {
         "micromark-factory-space": "^1.0.0",
         "micromark-util-character": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "mdast-util-from-markdown": "^1.3.0",
     "mdast-util-frontmatter": "1.0.1",
     "mdast-util-gfm-table": "^1.0.7",
+    "mdast-util-gfm-task-list-item": "^2.0.0",
     "mdast-util-mdx": "2.0.1",
     "mdast-util-mdx-jsx": "^2.1.4",
     "mdast-util-to-hast": "^12.3.0",
@@ -77,6 +78,7 @@
     "micromark-extension-directive": "2.2.0",
     "micromark-extension-frontmatter": "1.1.0",
     "micromark-extension-gfm-table": "^1.0.6",
+    "micromark-extension-gfm-task-list-item": "^2.0.1",
     "micromark-extension-mdxjs": "1.0.1",
     "react-hook-form": "^7.44.2",
     "unidiff": "^1.0.2"

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "mdast-util-from-markdown": "^1.3.0",
     "mdast-util-frontmatter": "1.0.1",
     "mdast-util-gfm-table": "^1.0.7",
-    "mdast-util-gfm-task-list-item": "^2.0.0",
+    "mdast-util-gfm-task-list-item": "1.0.2",
     "mdast-util-mdx": "2.0.1",
     "mdast-util-mdx-jsx": "^2.1.4",
     "mdast-util-to-hast": "^12.3.0",
@@ -78,7 +78,7 @@
     "micromark-extension-directive": "2.2.0",
     "micromark-extension-frontmatter": "1.1.0",
     "micromark-extension-gfm-table": "^1.0.6",
-    "micromark-extension-gfm-task-list-item": "^2.0.1",
+    "micromark-extension-gfm-task-list-item": "1.0.5",
     "micromark-extension-mdxjs": "1.0.1",
     "react-hook-form": "^7.44.2",
     "unidiff": "^1.0.2"

--- a/src/examples/basics.tsx
+++ b/src/examples/basics.tsx
@@ -124,6 +124,10 @@ const listsMarkdown = `
 
 1. more
 2. more
+
+* [x] Walk the dog
+* [ ] Watch movie
+* [ ] Have dinner with family
 `
 
 export function Lists() {

--- a/src/icons/format_list_checked.svg
+++ b/src/icons/format_list_checked.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="currentColor" viewBox="0 0 24 24">
+  <mask id="a" width="24" height="24" x="0" y="0" maskUnits="userSpaceOnUse" style="mask-type:alpha">
+    <path d="M0 0h24v24H0z"/>
+  </mask>
+  <g mask="url(#a)">
+    <path stroke-linejoin="round" d="M2 5.5L3.214 7L7.5 3M2 12.5L3.214 14L7.5 10M2 19.5L3.214 21L7.5 17"/>
+    <path d="M22 12h-5m-5 0h1.5M12 19h5m3.5 0H22m0-14H12"/>
+  </g>
+</svg>

--- a/src/icons/format_list_checked.svg
+++ b/src/icons/format_list_checked.svg
@@ -2,7 +2,7 @@
   <mask id="a" width="24" height="24" x="0" y="0" maskUnits="userSpaceOnUse" style="mask-type:alpha">
     <path d="M0 0h24v24H0z"/>
   </mask>
-  <g fill="none" stroke="#000000" stroke-linecap="round" stroke-width="1.5">
+  <g mask="url(#a)" fill="none" stroke="#000000" stroke-linecap="round" stroke-width="1.5">
     <path stroke-linejoin="round" d="M2 5.5L3.214 7L7.5 3M2 12.5L3.214 14L7.5 10M2 19.5L3.214 21L7.5 17"/>
     <path d="M22 12h-5m-5 0h1.5M12 19h5m3.5 0H22m0-14H12"/>
   </g>

--- a/src/icons/format_list_checked.svg
+++ b/src/icons/format_list_checked.svg
@@ -2,7 +2,7 @@
   <mask id="a" width="24" height="24" x="0" y="0" maskUnits="userSpaceOnUse" style="mask-type:alpha">
     <path d="M0 0h24v24H0z"/>
   </mask>
-  <g mask="url(#a)">
+  <g fill="none" stroke="#000000" stroke-linecap="round" stroke-width="1.5">
     <path stroke-linejoin="round" d="M2 5.5L3.214 7L7.5 3M2 12.5L3.214 14L7.5 10M2 19.5L3.214 21L7.5 17"/>
     <path d="M22 12h-5m-5 0h1.5M12 19h5m3.5 0H22m0-14H12"/>
   </g>

--- a/src/icons/format_list_checked.svg
+++ b/src/icons/format_list_checked.svg
@@ -1,9 +1,10 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="currentColor" viewBox="0 0 24 24">
-  <mask id="a" width="24" height="24" x="0" y="0" maskUnits="userSpaceOnUse" style="mask-type:alpha">
-    <path d="M0 0h24v24H0z"/>
-  </mask>
-  <g mask="url(#a)" fill="none" stroke="#000000" stroke-linecap="round" stroke-width="1.5">
-    <path stroke-linejoin="round" d="M2 5.5L3.214 7L7.5 3M2 12.5L3.214 14L7.5 10M2 19.5L3.214 21L7.5 17"/>
-    <path d="M22 12h-5m-5 0h1.5M12 19h5m3.5 0H22m0-14H12"/>
-  </g>
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<mask id="mask0_592_44" style="mask-type:alpha" maskUnits="userSpaceOnUse" x="0" y="0" width="24" height="24">
+<rect width="24" height="24" fill="#D9D9D9"/>
+</mask>
+<g mask="url(#mask0_592_44)">
+<path d="M5.55 15L2 11.45L3.4 10.05L5.525 12.175L9.775 7.925L11.175 9.35L5.55 15ZM5.55 9L2 5.45L3.4 4.05L5.525 6.175L9.775 1.925L11.175 3.35L5.55 9ZM13 13V11H22V13H13ZM13 7V5H22V7H13Z" fill="black"/>
+<path d="M13 19V17H22V19H13Z" fill="black"/>
+<path d="M5.55 21L2 17.45L3.4 16.05L5.525 18.175L9.775 13.925L11.175 15.35L5.55 21Z" fill="black"/>
+</g>
 </svg>

--- a/src/plugins/lists/LexicalListItemVisitor.ts
+++ b/src/plugins/lists/LexicalListItemVisitor.ts
@@ -16,6 +16,7 @@ export const LexicalListItemVisitor: LexicalExportVisitor<ListItemNode, Mdast.Li
       // nest the children in a paragraph for MDAST compatibility
       const listItem = actions.appendToParent(mdastParent, {
         type: 'listItem' as const,
+        checked: lexicalNode.getChecked(),
         spread: false,
         children: [{ type: 'paragraph' as const, children: [] }]
       }) as Mdast.ListItem

--- a/src/plugins/lists/MdastListItemVisitor.ts
+++ b/src/plugins/lists/MdastListItemVisitor.ts
@@ -4,7 +4,7 @@ import { MdastImportVisitor } from '../../importMarkdownToLexical'
 
 export const MdastListItemVisitor: MdastImportVisitor<Mdast.ListItem> = {
   testNode: 'listItem',
-  visitNode({ actions }) {
-    actions.addAndStepInto($createListItemNode())
+  visitNode({ mdastNode, actions }) {
+    actions.addAndStepInto($createListItemNode(mdastNode.checked ?? undefined))
   }
 }

--- a/src/plugins/lists/MdastListVisitor.ts
+++ b/src/plugins/lists/MdastListVisitor.ts
@@ -6,7 +6,8 @@ import { MdastImportVisitor } from '../../importMarkdownToLexical'
 export const MdastListVisitor: MdastImportVisitor<Mdast.List> = {
   testNode: 'list',
   visitNode: function ({ mdastNode, lexicalParent, actions }): void {
-    const lexicalNode = $createListNode(mdastNode.ordered ? 'number' : 'bullet')
+    const listType = mdastNode.children?.some((e) => typeof e.checked === 'boolean') ? 'check' : mdastNode.ordered ? 'number' : 'bullet'
+    const lexicalNode = $createListNode(listType)
 
     if ($isListItemNode(lexicalParent)) {
       const dedicatedParent = $createListItemNode()

--- a/src/plugins/lists/index.ts
+++ b/src/plugins/lists/index.ts
@@ -5,6 +5,7 @@ import { MdastListItemVisitor } from './MdastListItemVisitor'
 import { LexicalListVisitor } from './LexicalListVisitor'
 import { LexicalListItemVisitor } from './LexicalListItemVisitor'
 import {
+  INSERT_CHECK_LIST_COMMAND,
   INSERT_ORDERED_LIST_COMMAND,
   INSERT_UNORDERED_LIST_COMMAND,
   ListItemNode,
@@ -16,12 +17,18 @@ import { $isRootOrShadowRoot, LexicalCommand, RangeSelection } from 'lexical'
 import { $getListDepth, $isListItemNode, $isListNode } from '@lexical/list'
 import { $getSelection, $isElementNode, $isRangeSelection, COMMAND_PRIORITY_CRITICAL, ElementNode, INDENT_CONTENT_COMMAND } from 'lexical'
 import { TabIndentationPlugin } from '@lexical/react/LexicalTabIndentationPlugin.js'
+import { CheckListPlugin } from '@lexical/react/LexicalCheckListPlugin.js'
 import { ListPlugin } from '@lexical/react/LexicalListPlugin.js'
+
 import { $findMatchingParent, $getNearestNodeOfType } from '@lexical/utils'
+
+import { gfmTaskListItem } from 'micromark-extension-gfm-task-list-item'
+import { gfmTaskListItemFromMarkdown, gfmTaskListItemToMarkdown } from 'mdast-util-gfm-task-list-item'
 
 const ListTypeCommandMap = new Map<ListType | '', LexicalCommand<void>>([
   ['number', INSERT_ORDERED_LIST_COMMAND],
   ['bullet', INSERT_UNORDERED_LIST_COMMAND],
+  ['check', INSERT_CHECK_LIST_COMMAND],
   ['', REMOVE_LIST_COMMAND]
 ])
 
@@ -82,16 +89,20 @@ export const [
   systemSpec: listsSystem,
 
   init: (realm) => {
+    realm.pubKey('addMdastExtension', gfmTaskListItemFromMarkdown())
+    realm.pubKey('addSyntaxExtension', gfmTaskListItem())
     realm.pubKey('addImportVisitor', MdastListVisitor)
     realm.pubKey('addImportVisitor', MdastListItemVisitor)
     realm.pubKey('addLexicalNode', ListItemNode)
     realm.pubKey('addLexicalNode', ListNode)
     realm.pubKey('addExportVisitor', LexicalListVisitor)
     realm.pubKey('addExportVisitor', LexicalListItemVisitor)
+    realm.pubKey('addToMarkdownExtension', gfmTaskListItemToMarkdown())
 
     realm.getKeyValue('rootEditor')?.registerCommand(INDENT_CONTENT_COMMAND, () => !isIndentPermitted(7), COMMAND_PRIORITY_CRITICAL)
     realm.pubKey('addComposerChild', TabIndentationPlugin)
     realm.pubKey('addComposerChild', ListPlugin)
+    realm.pubKey('addComposerChild', CheckListPlugin)
   }
 })
 

--- a/src/plugins/lists/index.ts
+++ b/src/plugins/lists/index.ts
@@ -89,15 +89,15 @@ export const [
   systemSpec: listsSystem,
 
   init: (realm) => {
-    realm.pubKey('addMdastExtension', gfmTaskListItemFromMarkdown())
-    realm.pubKey('addSyntaxExtension', gfmTaskListItem())
+    realm.pubKey('addMdastExtension', gfmTaskListItemFromMarkdown)
+    realm.pubKey('addSyntaxExtension', gfmTaskListItem)
     realm.pubKey('addImportVisitor', MdastListVisitor)
     realm.pubKey('addImportVisitor', MdastListItemVisitor)
     realm.pubKey('addLexicalNode', ListItemNode)
     realm.pubKey('addLexicalNode', ListNode)
     realm.pubKey('addExportVisitor', LexicalListVisitor)
     realm.pubKey('addExportVisitor', LexicalListItemVisitor)
-    realm.pubKey('addToMarkdownExtension', gfmTaskListItemToMarkdown())
+    realm.pubKey('addToMarkdownExtension', gfmTaskListItemToMarkdown)
 
     realm.getKeyValue('rootEditor')?.registerCommand(INDENT_CONTENT_COMMAND, () => !isIndentPermitted(7), COMMAND_PRIORITY_CRITICAL)
     realm.pubKey('addComposerChild', TabIndentationPlugin)

--- a/src/plugins/markdown-shortcut/index.tsx
+++ b/src/plugins/markdown-shortcut/index.tsx
@@ -12,7 +12,8 @@ import {
   ORDERED_LIST,
   QUOTE,
   TextFormatTransformer,
-  UNORDERED_LIST
+  UNORDERED_LIST,
+  CHECK_LIST
 } from '@lexical/markdown'
 import { MarkdownShortcutPlugin } from '@lexical/react/LexicalMarkdownShortcutPlugin.js'
 import React from 'react'
@@ -97,7 +98,7 @@ function pickTransformersForActivePlugins(pluginIds: string[], allowedHeadingLev
     transformers.push(LINK)
   }
   if (pluginIds.includes('lists')) {
-    transformers.push(ORDERED_LIST, UNORDERED_LIST)
+    transformers.push(ORDERED_LIST, UNORDERED_LIST, CHECK_LIST)
   }
 
   if (pluginIds.includes('codeblock')) {

--- a/src/plugins/table/index.ts
+++ b/src/plugins/table/index.ts
@@ -18,30 +18,30 @@ type InsertTablePayload = {
   columns?: number
 }
 
-function seedTable(rows: number = 1, columns : number = 1): Mdast.Table {
+function seedTable(rows: number = 1, columns: number = 1): Mdast.Table {
   const table: Mdast.Table = {
     type: 'table',
     children: []
-  };
+  }
 
   for (let i = 0; i < rows; i++) {
     const tableRow: Mdast.TableRow = {
       type: 'tableRow',
       children: []
-    };
+    }
 
     for (let j = 0; j < columns; j++) {
       const cell: Mdast.TableCell = {
         type: 'tableCell',
         children: []
-      };
-      tableRow.children.push(cell);
+      }
+      tableRow.children.push(cell)
     }
 
-    table.children.push(tableRow);
+    table.children.push(tableRow)
   }
 
-  return table;
+  return table
 }
 
 /** @internal */
@@ -52,7 +52,7 @@ export const tableSystem = system(
     r.link(
       r.pipe(
         insertTable,
-        r.o.map(({rows, columns}) => {
+        r.o.map(({ rows, columns }) => {
           return () => $createTableNode(seedTable(rows, columns))
         })
       ),

--- a/src/plugins/toolbar/components/InsertTable.tsx
+++ b/src/plugins/toolbar/components/InsertTable.tsx
@@ -14,7 +14,7 @@ export const InsertTable: React.FC = () => {
     <ButtonWithTooltip
       title="Insert table"
       onClick={() => {
-        insertTable({rows: 3, columns: 3})
+        insertTable({ rows: 3, columns: 3 })
       }}
     >
       <TableIcon />

--- a/src/plugins/toolbar/components/ListsToggle.tsx
+++ b/src/plugins/toolbar/components/ListsToggle.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import BulletedListIcon from '../../../icons/format_list_bulleted.svg'
 import NumberedListIcon from '../../../icons/format_list_numbered.svg'
+import CheckedListIcon from '../../../icons/format_list_checked.svg'
 import { listsPluginHooks } from '../../lists'
 import { SingleChoiceToggleGroup } from '.././primitives/toolbar'
 
@@ -17,7 +18,8 @@ export const ListsToggle: React.FC = () => {
       value={currentListType || ''}
       items={[
         { title: 'Bulleted list', contents: <BulletedListIcon />, value: 'bullet' },
-        { title: 'Numbered list', contents: <NumberedListIcon />, value: 'number' }
+        { title: 'Numbered list', contents: <NumberedListIcon />, value: 'number' },
+        { title: 'Check list', contents: <CheckedListIcon />, value: 'check' }
       ]}
       onChange={applyListType}
     />

--- a/src/styles/lexical-theme.module.css
+++ b/src/styles/lexical-theme.module.css
@@ -60,6 +60,78 @@
   list-style:none;
 }
 
+.listitem {
+  margin: 8px 0;
+}
+
+.listItemChecked,
+.listItemUnchecked {
+  position: relative;
+  margin-left: 0;
+  margin-right: 0;
+  padding-left: 24px;
+  padding-right: 24px;
+  list-style-type: none;
+  outline: none;
+}
+
+.listItemChecked {
+  text-decoration: line-through;
+}
+
+.listItemUnchecked:before,
+.listItemChecked:before {
+  content: '';
+  width: 16px;
+  height: 16px;
+  top: 0;
+  left: 0;
+  cursor: pointer;
+  display: block;
+  background-size: cover;
+  position: absolute;
+}
+
+.listItemUnchecked[dir='rtl']:before,
+.listItemChecked[dir='rtl']:before {
+  left: auto;
+  right: 0;
+}
+
+.listItemUnchecked:focus:before,
+.listItemChecked:focus:before {
+  box-shadow: 0 0 0 2px #a6cdfe;
+  border-radius: 2px;
+}
+
+.listItemUnchecked:before {
+  border: 1px solid #999;
+  border-radius: 2px;
+}
+
+.listItemChecked:before {
+  border: 1px solid rgb(61, 135, 245);
+  border-radius: 2px;
+  background-color: #3d87f5;
+  background-repeat: no-repeat;
+}
+
+.listItemChecked:after {
+  content: '';
+  cursor: pointer;
+  border-color: #fff;
+  border-style: solid;
+  position: absolute;
+  display: block;
+  top: 4px;
+  width: 3px;
+  left: 7px;
+  right: 7px;
+  height: 6px;
+  transform: rotate(45deg);
+  border-width: 0 2px 2px 0;
+}
+
 .admonitionDanger, .admonitionInfo, .admonitionNote, .admonitionTip, .admonitionCaution {
   padding: var(--spacing-2);
   margin-top: var(--spacing-2);

--- a/src/styles/lexical-theme.module.css
+++ b/src/styles/lexical-theme.module.css
@@ -61,7 +61,7 @@
 }
 
 .listitem {
-  margin: 8px 0;
+  margin: var(--spacing-2) 0;
 }
 
 .listItemChecked,
@@ -69,8 +69,8 @@
   position: relative;
   margin-left: 0;
   margin-right: 0;
-  padding-left: 24px;
-  padding-right: 24px;
+  padding-left: var(--spacing-6);
+  padding-right: var(--spacing-6);
   list-style-type: none;
   outline: none;
 }
@@ -82,8 +82,8 @@
 .listItemUnchecked:before,
 .listItemChecked:before {
   content: '';
-  width: 16px;
-  height: 16px;
+  width: var(--spacing-4);
+  height: var(--spacing-4);
   top: 0;
   left: 0;
   cursor: pointer;
@@ -100,19 +100,19 @@
 
 .listItemUnchecked:focus:before,
 .listItemChecked:focus:before {
-  box-shadow: 0 0 0 2px #a6cdfe;
-  border-radius: 2px;
+  box-shadow: 0 0 0 2px var(--accentBorderHover);
+  border-radius: var(--radius-small);
 }
 
 .listItemUnchecked:before {
   border: 1px solid #999;
-  border-radius: 2px;
+  border-radius: var(--radius-small);
 }
 
 .listItemChecked:before {
-  border: 1px solid rgb(61, 135, 245);
-  border-radius: 2px;
-  background-color: #3d87f5;
+  border: 1px solid var(--accentBorder);
+  border-radius: var(--radius-small);
+  background-color: var(--accentSolid);
   background-repeat: no-repeat;
 }
 
@@ -123,13 +123,13 @@
   border-style: solid;
   position: absolute;
   display: block;
-  top: 4px;
-  width: 3px;
-  left: 7px;
-  right: 7px;
-  height: 6px;
+  top: var(--spacing-0_5);
+  width: var(--spacing-1);
+  left: var(--spacing-1_5);
+  right: var(--spacing-1_5);
+  height: var(--spacing-2);
   transform: rotate(45deg);
-  border-width: 0 2px 2px 0;
+  border-width: 0 var(--spacing-0_5) var(--spacing-0_5) 0;
 }
 
 .admonitionDanger, .admonitionInfo, .admonitionNote, .admonitionTip, .admonitionCaution {

--- a/src/styles/lexical-theme.module.css
+++ b/src/styles/lexical-theme.module.css
@@ -69,6 +69,7 @@
   position: relative;
   margin-left: 0;
   margin-right: 0;
+  margin-inline-start: -1rem;
   padding-left: var(--spacing-6);
   padding-right: var(--spacing-6);
   list-style-type: none;
@@ -100,12 +101,12 @@
 
 .listItemUnchecked:focus:before,
 .listItemChecked:focus:before {
-  box-shadow: 0 0 0 2px var(--accentBorderHover);
+  box-shadow: 0 0 0 2px var(--accentBgActive);
   border-radius: var(--radius-small);
 }
 
 .listItemUnchecked:before {
-  border: 1px solid #999;
+  border: 1px solid var(--baseBorder);
   border-radius: var(--radius-small);
 }
 
@@ -119,7 +120,7 @@
 .listItemChecked:after {
   content: '';
   cursor: pointer;
-  border-color: #fff;
+  border-color: var(--baseBase);
   border-style: solid;
   position: absolute;
   display: block;

--- a/src/styles/lexicalTheme.ts
+++ b/src/styles/lexicalTheme.ts
@@ -14,6 +14,9 @@ export const lexicalTheme: EditorThemeClasses = {
   },
 
   list: {
+    listitem: styles.listitem,
+    listitemChecked: styles.listItemChecked,
+    listitemUnchecked: styles.listItemUnchecked,
     nested: {
       listitem: styles.nestedListItem
     }


### PR DESCRIPTION
This is to add check list type in the current `list` plugin, the check list type is built on top of the following utilities:

1. `mdast-util-gfm-task-list-item`
2. `micromark-extension-gfm-task-list-item`
3. lexical CheckListPlugin

https://github.com/mdx-editor/editor/assets/706422/e6db49a5-f90e-4b4c-93c1-85a91409300b


