### PR TITLE
feat: Support rows and columns for insertTable

### DIFF
--- a/src/plugins/table/index.ts
+++ b/src/plugins/table/index.ts
@@ -7,28 +7,53 @@ import { LexicalTableVisitor } from './LexicalTableVisitor'
 import { MdastTableVisitor } from './MdastTableVisitor'
 import { $createTableNode, TableNode } from './TableNode'
 
-function seedTable(): Mdast.Table {
-  return {
+type InsertTablePayload = {
+  /**
+   * The nunber of rows of the table.
+   */
+  rows?: number
+  /**
+   * The nunber of columns of the table.
+   */
+  columns?: number
+}
+
+function seedTable(rows: number = 1, columns : number = 1): Mdast.Table {
+  const table: Mdast.Table = {
     type: 'table',
-    children: [
-      {
-        type: 'tableRow',
-        children: [{ type: 'tableCell', children: [] }]
-      }
-    ]
+    children: []
+  };
+
+  for (let i = 0; i < rows; i++) {
+    const tableRow: Mdast.TableRow = {
+      type: 'tableRow',
+      children: []
+    };
+
+    for (let j = 0; j < columns; j++) {
+      const cell: Mdast.TableCell = {
+        type: 'tableCell',
+        children: []
+      };
+      tableRow.children.push(cell);
+    }
+
+    table.children.push(tableRow);
   }
+
+  return table;
 }
 
 /** @internal */
 export const tableSystem = system(
   (r, [{ insertDecoratorNode }]) => {
-    const insertTable = r.node<true>()
+    const insertTable = r.node<InsertTablePayload>()
 
     r.link(
       r.pipe(
         insertTable,
-        r.o.mapTo(() => {
-          return $createTableNode(seedTable())
+        r.o.map(({rows, columns}) => {
+          return () => $createTableNode(seedTable(rows, columns))
         })
       ),
       insertDecoratorNode

--- a/src/plugins/toolbar/components/InsertTable.tsx
+++ b/src/plugins/toolbar/components/InsertTable.tsx
@@ -14,7 +14,7 @@ export const InsertTable: React.FC = () => {
     <ButtonWithTooltip
       title="Insert table"
       onClick={() => {
-        insertTable(true)
+        insertTable({rows: 3, columns: 3})
       }}
     >
       <TableIcon />


### PR DESCRIPTION
We can specify the `rows` and `columns` in `insertTable` hook to insert a initial table with the specific number of rows and columns.

https://github.com/mdx-editor/editor/assets/706422/5848ebd1-97cf-4991-946f-8d973fe9626e

