### PR TITLE
Export 'utils'

### DIFF
--- a/package.json
+++ b/package.json
@@ -231,6 +231,11 @@
       "import": "./dist/plugins/core/NestedLexicalEditor.js",
       "default": "./dist/plugins/core/NestedLexicalEditor.js"
     },
+    "./utils": {
+      "types": "./dist/utils.d.ts",
+      "import": "./dist/utils.js",
+      "default": "./dist/utils.js"
+    },
     "./plugins/codeblock": {
       "types": "./dist/plugins/codeblock/index.d.ts",
       "import": "./dist/plugins/codeblock/index.js",

--- a/scripts/generate-exports.js
+++ b/scripts/generate-exports.js
@@ -27,6 +27,7 @@ const additionalExports = [
   'jsx-editors/GenericJsxEditor',
   'plugins/core/PropertyPopover',
   'plugins/core/NestedLexicalEditor',
+  'utils',
 ]
 
 additionalExports.forEach(exp => { 

--- a/src/index.ts
+++ b/src/index.ts
@@ -77,4 +77,14 @@ export * from './plugins/toolbar/primitives/select'
 export * from './plugins/core/NestedLexicalEditor'
 export * from './plugins/core/PropertyPopover'
 
+// Helpers & utilities
+export * from './utils/detectMac'
+export * from './utils/fp'
+export * from './utils/isPartOftheEditorUI'
+export * from './utils/lexicalHelpers'
+export * from './utils/makeHslTransparent'
+export * from './utils/uuid4'
+export * from './utils/voidEmitter'
+export * from './utils/whitespaceConversion'
+
 export * from './gurx'


### PR DESCRIPTION
This PR exports everything under `utils` for convenience when recreating components, eg for the toolbar (like `IS_APPLE` and other helpful functions / variables etc) - let me know if that's something worth doing from your pov!