### PR TITLE
Capitalize admonition name for ChangeAdmonitionType

### DIFF
--- a/src/plugins/toolbar/components/ChangeAdmonitionType.tsx
+++ b/src/plugins/toolbar/components/ChangeAdmonitionType.tsx
@@ -27,7 +27,7 @@ export const ChangeAdmonitionType = () => {
       }}
       triggerTitle="Select admonition type"
       placeholder="Admonition type"
-      items={ADMONITION_TYPES.map((type) => ({ label: type, value: type }))}
+      items={ADMONITION_TYPES.map((type) => ({ label: type.replace(/^./, (l) => l.toUpperCase()), value: type }))}
     />
   )
 }


### PR DESCRIPTION
Update the label of ChangeAdmonitionType to capitalize the first letter of admonition name, which aligns the logic in [InsertAdmonition](https://github.com/mdx-editor/editor/blob/main/src/plugins/toolbar/components/InsertAdmonition.tsx#L14)