### PR TITLE
Add  a callback for click link in link-dialog plugin.

### DIFF
--- a/src/plugins/link-dialog/LinkDialog.tsx
+++ b/src/plugins/link-dialog/LinkDialog.tsx
@@ -19,7 +19,8 @@ import {
   removeLink$,
   switchFromPreviewToLinkEdit$,
   updateLink$,
-  onClickLinkCallback$
+  onClickLinkCallback$,
+  clickLink$
 } from '.'
 import { useCellValues, usePublisher } from '@mdxeditor/gurx'
 
@@ -110,6 +111,7 @@ export const LinkDialog: React.FC = () => {
   const cancelLinkEdit = usePublisher(cancelLinkEdit$)
   const switchFromPreviewToLinkEdit = usePublisher(switchFromPreviewToLinkEdit$)
   const removeLink = usePublisher(removeLink$)
+  const clickLink = usePublisher(clickLink$)
 
   React.useEffect(() => {
     const update = () => {
@@ -166,7 +168,7 @@ export const LinkDialog: React.FC = () => {
           {linkDialogState.type === 'preview' && (
             <>
               {onClickLinkCallback$ !== null && (
-                <a className={styles.linkDialogPreviewAnchor} href="javascript:;" onClick={onClickLinkCallback$}>
+                <a className={styles.linkDialogPreviewAnchor} href="javascript:;" onClick={() => clickLink()}>
                   <span>{linkDialogState.url}</span>
                   {urlIsExternal && iconComponentFor('open_in_new')}
                 </a>

--- a/src/plugins/link-dialog/LinkDialog.tsx
+++ b/src/plugins/link-dialog/LinkDialog.tsx
@@ -18,7 +18,8 @@ import {
   onWindowChange$,
   removeLink$,
   switchFromPreviewToLinkEdit$,
-  updateLink$
+  updateLink$,
+  onClickLinkCallback$
 } from '.'
 import { useCellValues, usePublisher } from '@mdxeditor/gurx'
 
@@ -164,15 +165,24 @@ export const LinkDialog: React.FC = () => {
 
           {linkDialogState.type === 'preview' && (
             <>
-              <a
-                className={styles.linkDialogPreviewAnchor}
-                href={linkDialogState.url}
-                {...(urlIsExternal ? { target: '_blank', rel: 'noreferrer' } : {})}
-                title={urlIsExternal ? `Open ${linkDialogState.url} in new window` : linkDialogState.url}
-              >
-                <span>{linkDialogState.url}</span>
-                {urlIsExternal && iconComponentFor('open_in_new')}
-              </a>
+              {onClickLinkCallback$ !== null && (
+                <a className={styles.linkDialogPreviewAnchor} href="javascript:;" onClick={onClickLinkCallback$}>
+                  <span>{linkDialogState.url}</span>
+                  {urlIsExternal && iconComponentFor('open_in_new')}
+                </a>
+              )}
+              {onClickLinkCallback$ === null && (
+                <a
+                  className={styles.linkDialogPreviewAnchor}
+                  href={linkDialogState.url}
+                  {...(urlIsExternal ? { target: '_blank', rel: 'noreferrer' } : {})}
+                  title={urlIsExternal ? `Open ${linkDialogState.url} in new window` : linkDialogState.url}
+                >
+                  <span>{linkDialogState.url}</span>
+                  {urlIsExternal && iconComponentFor('open_in_new')}
+                </a>
+              )}
+
               <ActionButton onClick={() => switchFromPreviewToLinkEdit()} title="Edit link URL" aria-label="Edit link URL">
                 {iconComponentFor('edit')}
               </ActionButton>

--- a/src/plugins/link-dialog/LinkDialog.tsx
+++ b/src/plugins/link-dialog/LinkDialog.tsx
@@ -19,8 +19,7 @@ import {
   removeLink$,
   switchFromPreviewToLinkEdit$,
   updateLink$,
-  onClickLinkCallback$,
-  clickLink$
+  onClickLinkCallback$
 } from '.'
 import { useCellValues, usePublisher } from '@mdxeditor/gurx'
 
@@ -99,19 +98,20 @@ export function LinkEditForm({ url, title, onSubmit, onCancel, linkAutocompleteS
 
 /** @internal */
 export const LinkDialog: React.FC = () => {
-  const [editorRootElementRef, activeEditor, iconComponentFor, linkDialogState, linkAutocompleteSuggestions] = useCellValues(
-    editorRootElementRef$,
-    activeEditor$,
-    iconComponentFor$,
-    linkDialogState$,
-    linkAutocompleteSuggestions$
-  )
+  const [editorRootElementRef, activeEditor, iconComponentFor, linkDialogState, linkAutocompleteSuggestions, onClickLinkCallback] =
+    useCellValues(
+      editorRootElementRef$,
+      activeEditor$,
+      iconComponentFor$,
+      linkDialogState$,
+      linkAutocompleteSuggestions$,
+      onClickLinkCallback$
+    )
   const publishWindowChange = usePublisher(onWindowChange$)
   const updateLink = usePublisher(updateLink$)
   const cancelLinkEdit = usePublisher(cancelLinkEdit$)
   const switchFromPreviewToLinkEdit = usePublisher(switchFromPreviewToLinkEdit$)
   const removeLink = usePublisher(removeLink$)
-  const clickLink = usePublisher(clickLink$)
 
   React.useEffect(() => {
     const update = () => {
@@ -167,23 +167,21 @@ export const LinkDialog: React.FC = () => {
 
           {linkDialogState.type === 'preview' && (
             <>
-              {onClickLinkCallback$ !== null && (
-                <a className={styles.linkDialogPreviewAnchor} href="javascript:;" onClick={() => clickLink()}>
-                  <span>{linkDialogState.url}</span>
-                  {urlIsExternal && iconComponentFor('open_in_new')}
-                </a>
-              )}
-              {onClickLinkCallback$ === null && (
-                <a
-                  className={styles.linkDialogPreviewAnchor}
-                  href={linkDialogState.url}
-                  {...(urlIsExternal ? { target: '_blank', rel: 'noreferrer' } : {})}
-                  title={urlIsExternal ? `Open ${linkDialogState.url} in new window` : linkDialogState.url}
-                >
-                  <span>{linkDialogState.url}</span>
-                  {urlIsExternal && iconComponentFor('open_in_new')}
-                </a>
-              )}
+              <a
+                className={styles.linkDialogPreviewAnchor}
+                href={linkDialogState.url}
+                {...(urlIsExternal ? { target: '_blank', rel: 'noreferrer' } : {})}
+                onClick={(e) => {
+                  if (onClickLinkCallback !== null) {
+                    e.preventDefault()
+                    onClickLinkCallback(linkDialogState.url)
+                  }
+                }}
+                title={urlIsExternal ? `Open ${linkDialogState.url} in new window` : linkDialogState.url}
+              >
+                <span>{linkDialogState.url}</span>
+                {urlIsExternal && iconComponentFor('open_in_new')}
+              </a>
 
               <ActionButton onClick={() => switchFromPreviewToLinkEdit()} title="Edit link URL" aria-label="Edit link URL">
                 {iconComponentFor('edit')}

--- a/src/plugins/link-dialog/index.ts
+++ b/src/plugins/link-dialog/index.ts
@@ -327,8 +327,17 @@ export const onClickLinkCallback$ = Cell<ClickLinkCallback | null>(null)
  * @group Link Dialog
  */
 export const linkDialogPlugin = realmPlugin<{
+  /**
+   * If passed, the link dialog will be rendered using this component instead of the default one.
+   */
   LinkDialog?: () => JSX.Element
+  /**
+   * If passed, the link input field will autocomplete using the published suggestions.
+   */
   linkAutocompleteSuggestions?: string[]
+  /**
+   * If set, clicking on the link in the preview popup will call this callback instead of opening the link.
+   */
   onClickLinkCallback?: ClickLinkCallback
 }>({
   init(r, params) {

--- a/src/plugins/link-dialog/index.ts
+++ b/src/plugins/link-dialog/index.ts
@@ -214,6 +214,24 @@ export const linkDialogState$ = Cell<InactiveLinkDialog | PreviewLinkDialog | Ed
 
   r.link(
     r.pipe(
+      clickLink$,
+      withLatestFrom(linkDialogState$, activeEditor$),
+      map(([, state, editor]) => {
+        if (onClickLinkCallback$) {
+          const stateAct = state as PreviewLinkDialog
+          onClickLinkCallback$(stateAct.url)
+        }
+
+        return {
+          type: 'inactive' as const
+        } as InactiveLinkDialog
+      })
+    ),
+    linkDialogState$
+  )
+
+  r.link(
+    r.pipe(
       r.combine(currentSelection$, onWindowChange$),
       withLatestFrom(activeEditor$, linkDialogState$),
       map(([[selection], activeEditor]) => {
@@ -250,6 +268,11 @@ export const updateLink$ = Signal<{ url: string; title: string }>()
  * @group Link Dialog
  */
 export const cancelLinkEdit$ = Action()
+/**
+ * A signal that click on the current link.
+ * @group Link Dialog
+ */
+export const clickLink$ = Action()
 /**
  * A signal that confirms the updated values of the current link.
  * @group Link Dialog
@@ -318,7 +341,7 @@ export const openLinkEditDialog$ = Action((r) => {
 /** @internal */
 export const linkAutocompleteSuggestions$ = Cell<string[]>([])
 
-export type ClickLinkCallback = (event: React.MouseEvent<HTMLAnchorElement, MouseEvent>) => void
+export type ClickLinkCallback = (url: string) => void
 
 /** @internal */
 export let onClickLinkCallback$: ClickLinkCallback | null = null
@@ -341,4 +364,3 @@ export const linkDialogPlugin = realmPlugin<{
     r.pub(linkAutocompleteSuggestions$, params.linkAutocompleteSuggestions || [])
   }
 })
-

--- a/src/plugins/link-dialog/index.ts
+++ b/src/plugins/link-dialog/index.ts
@@ -318,17 +318,27 @@ export const openLinkEditDialog$ = Action((r) => {
 /** @internal */
 export const linkAutocompleteSuggestions$ = Cell<string[]>([])
 
+export type ClickLinkCallback = (event: React.MouseEvent<HTMLAnchorElement, MouseEvent>) => void
+
+/** @internal */
+export let onClickLinkCallback$: ClickLinkCallback | null = null
+
 /**
  * @group Link Dialog
  */
 export const linkDialogPlugin = realmPlugin<{
   LinkDialog?: () => JSX.Element
   linkAutocompleteSuggestions?: string[]
+  onClickLinkCallback?: ClickLinkCallback
 }>({
   init(r, params) {
     r.pub(addComposerChild$, params?.LinkDialog || LinkDialog)
+    if (params?.onClickLinkCallback) {
+      onClickLinkCallback$ = params?.onClickLinkCallback
+    }
   },
   update(r, params = {}) {
     r.pub(linkAutocompleteSuggestions$, params.linkAutocompleteSuggestions || [])
   }
 })
+

--- a/src/plugins/link-dialog/index.ts
+++ b/src/plugins/link-dialog/index.ts
@@ -214,24 +214,6 @@ export const linkDialogState$ = Cell<InactiveLinkDialog | PreviewLinkDialog | Ed
 
   r.link(
     r.pipe(
-      clickLink$,
-      withLatestFrom(linkDialogState$, activeEditor$),
-      map(([, state, editor]) => {
-        if (onClickLinkCallback$) {
-          const stateAct = state as PreviewLinkDialog
-          onClickLinkCallback$(stateAct.url)
-        }
-
-        return {
-          type: 'inactive' as const
-        } as InactiveLinkDialog
-      })
-    ),
-    linkDialogState$
-  )
-
-  r.link(
-    r.pipe(
       r.combine(currentSelection$, onWindowChange$),
       withLatestFrom(activeEditor$, linkDialogState$),
       map(([[selection], activeEditor]) => {
@@ -268,11 +250,6 @@ export const updateLink$ = Signal<{ url: string; title: string }>()
  * @group Link Dialog
  */
 export const cancelLinkEdit$ = Action()
-/**
- * A signal that click on the current link.
- * @group Link Dialog
- */
-export const clickLink$ = Action()
 /**
  * A signal that confirms the updated values of the current link.
  * @group Link Dialog
@@ -344,7 +321,7 @@ export const linkAutocompleteSuggestions$ = Cell<string[]>([])
 export type ClickLinkCallback = (url: string) => void
 
 /** @internal */
-export let onClickLinkCallback$: ClickLinkCallback | null = null
+export const onClickLinkCallback$ = Cell<ClickLinkCallback | null>(null)
 
 /**
  * @group Link Dialog
@@ -356,9 +333,7 @@ export const linkDialogPlugin = realmPlugin<{
 }>({
   init(r, params) {
     r.pub(addComposerChild$, params?.LinkDialog || LinkDialog)
-    if (params?.onClickLinkCallback) {
-      onClickLinkCallback$ = params?.onClickLinkCallback
-    }
+    r.pub(onClickLinkCallback$, params?.onClickLinkCallback ?? null)
   },
   update(r, params = {}) {
     r.pub(linkAutocompleteSuggestions$, params.linkAutocompleteSuggestions || [])


### PR DESCRIPTION
Add  a callback for click link in **link-dialog** plugin.

So, developers can get the url that user clicked, and do some more actions.