### PR TITLE
codeBlockPlugin now can set theme

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
     "micromark-extension-mdx-md": "^2.0.0",
     "micromark-extension-mdxjs": "^3.0.0",
     "micromark-factory-space": "^2.0.0",
+    "micromark-util-character": "^2.0.1",
     "micromark-util-symbol": "^2.0.0",
     "react-hook-form": "^7.44.2",
     "unidiff": "^1.0.2"

--- a/src/plugins/codeblock/CodeBlockNode.tsx
+++ b/src/plugins/codeblock/CodeBlockNode.tsx
@@ -1,7 +1,7 @@
 import { useCellValue } from '@mdxeditor/gurx'
 import { DecoratorNode, EditorConfig, LexicalEditor, LexicalNode, NodeKey, SerializedLexicalNode, Spread } from 'lexical'
 import React from 'react'
-import { CodeBlockEditorProps } from '.'
+import { CodeBlockEditorProps, theme$ } from '.'
 import { voidEmitter } from '../../utils/voidEmitter'
 import { NESTED_EDITOR_UPDATED_COMMAND, codeBlockEditorDescriptors$ } from '../core'
 
@@ -127,6 +127,7 @@ export class CodeBlockNode extends DecoratorNode<JSX.Element> {
         codeBlockNode={this}
         nodeKey={this.getKey()}
         focusEmitter={this.__focusEmitter}
+        theme={'auto'}
       />
     )
   }
@@ -230,6 +231,7 @@ const CodeBlockEditorContainer: React.FC<
   const Editor = descriptor.Editor
 
   const { codeBlockNode: _, parentEditor: __, ...restProps } = props
+  restProps.theme = useCellValue(theme$)
 
   return (
     <CodeBlockEditorContextProvider parentEditor={props.parentEditor} lexicalNode={props.codeBlockNode}>

--- a/src/plugins/codeblock/index.ts
+++ b/src/plugins/codeblock/index.ts
@@ -13,6 +13,7 @@ import { $createCodeBlockNode, CodeBlockNode, CreateCodeBlockNodeOptions } from 
 import { VoidEmitter } from '../../utils/voidEmitter'
 import { Cell, Signal, map, withLatestFrom } from '@mdxeditor/gurx'
 import { realmPlugin } from '../../RealmWithPlugins'
+import { SandpackThemeProp } from '@codesandbox/sandpack-react/types'
 export * from './CodeBlockNode'
 
 export type { CodeBlockEditorContextValue, CreateCodeBlockNodeOptions } from './CodeBlockNode'
@@ -44,6 +45,11 @@ export interface CodeBlockEditorProps {
    * Note: you don't need to unsubscribe, the emiter has a single subscription model.
    */
   focusEmitter: VoidEmitter
+
+  /**
+   * The theme CodeMirrorEditor used.
+   */
+  theme: SandpackThemeProp
 }
 
 /**
@@ -74,6 +80,15 @@ export interface CodeBlockEditorDescriptor {
  * @group Code Block
  */
 export const defaultCodeBlockLanguage$ = Cell<string>('')
+
+/**
+ * The theme CodeMirrorEditor used.
+ * It can be "light" | "dark" | "auto",
+ * or the theme in "@codesandbox/sandpack-themes" package,
+ * or you can also custom one,
+ * learn more https://sandpack.codesandbox.io/docs/getting-started/themes#custom-theme
+ */
+export const theme$ = Cell<SandpackThemeProp>('auto')
 
 /**
  * A signal that inserts a new code block into the editor with the published options.
@@ -113,9 +128,14 @@ export const codeBlockPlugin = realmPlugin<{
    * The default language to use when creating a new code block if no language is passed.
    */
   defaultCodeBlockLanguage?: string
+  /**
+   * The theme of CodeMirrorEditor
+   */
+  theme?: SandpackThemeProp
 }>({
   update(realm, params) {
     realm.pub(defaultCodeBlockLanguage$, params?.defaultCodeBlockLanguage || '')
+    realm.pub(theme$, params?.theme || 'auto')
   },
 
   init(realm, params) {

--- a/src/plugins/codemirror/CodeMirrorEditor.tsx
+++ b/src/plugins/codemirror/CodeMirrorEditor.tsx
@@ -7,8 +7,7 @@ import { readOnly$ } from '../core'
 import { useCodeMirrorRef } from '../sandpack/useCodeMirrorRef'
 import { useCellValue } from '@mdxeditor/gurx'
 
-/** @internal */
-export const CodeMirrorEditor = ({ language, nodeKey, code, focusEmitter }: CodeBlockEditorProps) => {
+export const CodeMirrorEditor = ({ language, nodeKey, code, focusEmitter, theme }: CodeBlockEditorProps) => {
   const codeMirrorRef = useCodeMirrorRef(nodeKey, 'codeblock', 'jsx', focusEmitter)
   const readOnly = useCellValue(readOnly$)
   const { setCode } = useCodeBlockEditorContext()
@@ -26,7 +25,7 @@ export const CodeMirrorEditor = ({ language, nodeKey, code, focusEmitter }: Code
         e.stopPropagation()
       }}
     >
-      <SandpackProvider>
+      <SandpackProvider theme={theme}>
         <TheEditorFromSandpack
           readOnly={readOnly}
           showLineNumbers


### PR DESCRIPTION
## codeBlockPlugin now can set theme

It can be "light" | "dark" | "auto",
or the theme in "@codesandbox/sandpack-themes" package,
or you can also custom one,
just like: [sandpack docs](https://sandpack.codesandbox.io/docs/getting-started/themes#custom-theme)
