### PR TITLE
Automatically close link-dialog when user clicks the link if there is a onClickLinkCallback

### DIFF
--- a/src/examples/link-dialog.tsx
+++ b/src/examples/link-dialog.tsx
@@ -23,6 +23,22 @@ export function Basics() {
   )
 }
 
+export function WithCallback() {
+  return (
+    <MDXEditor
+      markdown={'Hello world [link](https://google.com/), and you can see an alert after you click the link in the dialog.'}
+      plugins={[
+        linkPlugin(),
+        linkDialogPlugin({
+          onClickLinkCallback: (url) => {
+            alert(`You clicked the url: ${url}`)
+          }
+        })
+      ]}
+    />
+  )
+}
+
 export function WithNestedEditors() {
   return (
     <MDXEditor

--- a/src/plugins/link-dialog/LinkDialog.tsx
+++ b/src/plugins/link-dialog/LinkDialog.tsx
@@ -19,7 +19,8 @@ import {
   removeLink$,
   switchFromPreviewToLinkEdit$,
   updateLink$,
-  onClickLinkCallback$
+  onClickLinkCallback$,
+  clickLink$
 } from '.'
 import { useCellValues, usePublisher } from '@mdxeditor/gurx'
 
@@ -112,6 +113,7 @@ export const LinkDialog: React.FC = () => {
   const cancelLinkEdit = usePublisher(cancelLinkEdit$)
   const switchFromPreviewToLinkEdit = usePublisher(switchFromPreviewToLinkEdit$)
   const removeLink = usePublisher(removeLink$)
+  const clickLink = usePublisher(clickLink$)
 
   React.useEffect(() => {
     const update = () => {
@@ -174,7 +176,8 @@ export const LinkDialog: React.FC = () => {
                 onClick={(e) => {
                   if (onClickLinkCallback !== null) {
                     e.preventDefault()
-                    onClickLinkCallback(linkDialogState.url)
+                    clickLink()
+                    onClickLinkCallback(linkDialogState.url)                    
                   }
                 }}
                 title={urlIsExternal ? `Open ${linkDialogState.url} in new window` : linkDialogState.url}

--- a/src/plugins/link-dialog/index.ts
+++ b/src/plugins/link-dialog/index.ts
@@ -212,6 +212,20 @@ export const linkDialogState$ = Cell<InactiveLinkDialog | PreviewLinkDialog | Ed
     linkDialogState$
   )
 
+
+  r.link(
+    r.pipe(
+      clickLink$,
+      withLatestFrom(linkDialogState$, activeEditor$),
+      map(([, state, editor]) => {
+        return {
+          type: 'inactive' as const
+        } as InactiveLinkDialog
+      })
+    ),
+    linkDialogState$
+  )
+
   r.link(
     r.pipe(
       r.combine(currentSelection$, onWindowChange$),
@@ -250,6 +264,11 @@ export const updateLink$ = Signal<{ url: string; title: string }>()
  * @group Link Dialog
  */
 export const cancelLinkEdit$ = Action()
+/**
+ * A signal that click on the current link.
+ * @group Link Dialog
+ */
+export const clickLink$ = Action()
 /**
  * A signal that confirms the updated values of the current link.
  * @group Link Dialog


### PR DESCRIPTION
This feature was included in [the previous PR](https://github.com/mdx-editor/editor/pull/335/commits/12bac169d14e88a92f4b73cf498102ca64978de2), and now it has been added back.