### PR TITLE
Add support for expression properties into JSX plugin

### DIFF
--- a/docs/jsx.md
+++ b/docs/jsx.md
@@ -21,7 +21,8 @@ const jsxComponentDescriptors: JsxComponentDescriptor[] = [
     // Used to construct the property popover of the generic editor
     props: [
       { name: 'foo', type: 'string' },
-      { name: 'bar', type: 'string' }
+      { name: 'bar', type: 'string' },
+      { name: 'onClick', type: 'expression' }
     ],
     // whether the component has children or not
     hasChildren: true,
@@ -65,7 +66,7 @@ const InsertMyLeaf = () => {
         insertJsx({
           name: 'MyLeaf',
           kind: 'text',
-          props: { foo: 'bar', bar: 'baz' }
+          props: { foo: 'bar', bar: 'baz', onClick: { type: 'expression', value: '() => console.log("Clicked")' } }
         })
       }
     >
@@ -97,11 +98,57 @@ export const Example = () => {
 ```md
 import { MyLeaf, BlockNode } from './external';
 
-A paragraph with inline jsx component <MyLeaf foo="fooValue">Nested _markdown_</MyLeaf> more <Marker type="warning" />.
+A paragraph with inline jsx component <MyLeaf foo="bar" bar="baz" onClick={() => console.log("Clicked")}>Nested _markdown_</MyLeaf> more <Marker type="warning" />.
 
 <BlockNode foo="fooValue">
  Content *foo*
 
 more Content
 </BlockNode>
+```
+
+## Types of properties
+
+There are two types of properties - "textual" and "expressions" in JSX. You can define type in `JsxComponentDescriptor`. `jsxPlugin` will treat the value based on this setting. For example, this code:
+
+```tsx
+const jsxComponentDescriptors: JsxComponentDescriptor[] = [
+  {
+    name: 'MyLeaf',
+    kind: 'text',
+    props: [
+      { name: 'foo', type: 'string' } // Textual property type
+    ],
+    hasChildren: true,
+    Editor: GenericJsxEditor
+  }
+]
+```
+
+will produce component like the following:
+
+```tsx
+<MyLeaf foo="bar">Some text...</MyLeaf>
+```
+
+While this descriptor:
+
+```tsx
+const jsxComponentDescriptors: JsxComponentDescriptor[] = [
+  {
+    name: 'MyLeaf',
+    kind: 'text',
+    props: [
+      { name: 'foo', type: 'expression' } // Expression property type
+    ],
+    hasChildren: true,
+    Editor: GenericJsxEditor
+  }
+]
+```
+
+will produce:
+
+```tsx
+<MyLeaf foo={bar}>Some text...</MyLeaf>
 ```

--- a/src/examples/basics.tsx
+++ b/src/examples/basics.tsx
@@ -66,7 +66,7 @@ const jsxComponentDescriptors: JsxComponentDescriptor[] = [
     source: './external',
     props: [
       { name: 'foo', type: 'string' },
-      { name: 'bar', type: 'string' }
+      { name: 'bar', type: 'expression' }
     ],
     hasChildren: true,
     Editor: GenericJsxEditor
@@ -105,7 +105,7 @@ export function Headings() {
   return <MDXEditor markdown="# hello world" plugins={[headingsPlugin()]} />
 }
 
-const breakMarkdown = `hello 
+const breakMarkdown = `hello
 
 ----------------
 

--- a/src/examples/jsx.tsx
+++ b/src/examples/jsx.tsx
@@ -129,3 +129,71 @@ export const JsxExpression = () => {
     </div>
   )
 }
+
+export const JsxFragment = () => {
+  return (
+    <div>
+      <MDXEditor
+        onChange={(e) => console.log(e)}
+        markdown={`# Fragment
+        <></>
+
+        # Nested fragment
+        <BlockNode><><BlockNode /><BlockNode /></></BlockNode>`}
+        plugins={[headingsPlugin(), jsxPlugin({ jsxComponentDescriptors })]}
+      />
+    </div>
+  )
+}
+
+const componentWithExpressionAttribute: JsxComponentDescriptor[] = [
+  {
+    name: 'BlockNode',
+    kind: 'flow',
+    source: './external',
+    props: [
+      {
+        name: 'onClick',
+        type: 'expression'
+      }
+    ],
+    Editor: GenericJsxEditor,
+    hasChildren: true
+  }
+]
+
+const InsertBlockNodeWithExpressionAttribute = () => {
+  const insertJsx = usePublisher(insertJsx$)
+  return (
+    <Button
+      onClick={() =>
+        insertJsx({
+          name: 'BlockNode',
+          kind: 'flow',
+          props: { onClick: { type: 'expression', value: '() => console.log' } },
+          children: [{ type: 'paragraph', children: [{ type: 'text', value: 'Hello, World!' }] }]
+        })
+      }
+    >
+      BlockNode
+    </Button>
+  )
+}
+
+export const ExpressionAttributes = () => {
+  return (
+    <div>
+      <MDXEditor
+        onChange={(e) => console.log(e)}
+        markdown={`<BlockNode>
+        Hello, World!
+        </BlockNode>`}
+        plugins={[
+          headingsPlugin(),
+          jsxPlugin({ jsxComponentDescriptors: componentWithExpressionAttribute }),
+          toolbarPlugin({ toolbarContents: InsertBlockNodeWithExpressionAttribute })
+        ]}
+      />
+    </div>
+  )
+}

--- a/src/plugins/core/index.ts
+++ b/src/plugins/core/index.ts
@@ -245,11 +245,16 @@ export const toMarkdownExtensions$ = Cell<NonNullable<LexicalConvertOptions['toM
 /** @internal */
 export const toMarkdownOptions$ = Cell<NonNullable<LexicalConvertOptions['toMarkdownOptions']>>({})
 
-// the JSX plugin will fill in these
-/** @internal */
+/**
+ * This JSX plugin will fill this value.
+ * @group JSX
+ */
 export const jsxIsAvailable$ = Cell(false)
 
-/** @internal */
+/**
+ * Contains the currently registered JSX component descriptors.
+ * @group JSX
+ */
 export const jsxComponentDescriptors$ = Cell<JsxComponentDescriptor[]>([])
 
 /**


### PR DESCRIPTION
This pull-request will introduce support for expression properties in JSX components. It will add support for handling fragments (`<></>`) as well.

**Description:**

There are two types of properties - "textual" and "expressions" in JSX. You can define type in `JsxComponentDescriptor`. `jsxPlugin` will treat the value based on this setting. For example, this code:

```tsx
const jsxComponentDescriptors: JsxComponentDescriptor[] = [
  {
    name: 'MyLeaf',
    kind: 'text',
    props: [
      { name: 'foo', type: 'string' } // Textual property type
    ],
    hasChildren: true,
    Editor: GenericJsxEditor
  }
]
```

will produce component like the following:

```tsx
<MyLeaf foo="bar">Some text...</MyLeaf>
```

While this descriptor:

```tsx
const jsxComponentDescriptors: JsxComponentDescriptor[] = [
  {
    name: 'MyLeaf',
    kind: 'text',
    props: [
      { name: 'foo', type: 'expression' } // Expression property type
    ],
    hasChildren: true,
    Editor: GenericJsxEditor
  }
]
```

will produce:

```tsx
<MyLeaf foo={bar}>Some text...</MyLeaf>
```