### PR TITLE
fix(table-editor): first row should be a header row using th instead of td element

### DIFF
--- a/src/plugins/table/TableEditor.tsx
+++ b/src/plugins/table/TableEditor.tsx
@@ -16,7 +16,7 @@ import {
   createEditor
 } from 'lexical'
 import * as Mdast from 'mdast'
-import React from 'react'
+import React, { ElementType, ReactNode } from 'react'
 import { exportLexicalTreeToMdast } from '../../exportMarkdownFromLexical'
 import { importMdastTreeToLexical } from '../../importMarkdownToLexical'
 import { lexicalTheme } from '../../styles/lexicalTheme'
@@ -45,6 +45,19 @@ import {
   usedLexicalNodes$
 } from '../core'
 import { useCellValues } from '@mdxeditor/gurx'
+
+/**
+ * Returns the element type for the cell based on the rowIndex
+ *
+ * If the rowIndex is 0, it returns 'th' for the header cell
+ * Otherwise, it returns 'td' for the data cell
+ */
+const getCellType = (rowIndex: number): ElementType => {
+  if (rowIndex === 0) {
+    return 'th'
+  }
+  return 'td'
+}
 
 const AlignToTailwindClassMap = {
   center: styles.centeredCell,
@@ -228,12 +241,13 @@ export const TableEditor: React.FC<TableEditorProps> = ({ mdastNode, parentEdito
 
       <tbody>
         {mdastNode.children.map((row, rowIndex) => {
+          const CellElement = getCellType(rowIndex)
           return (
             <tr key={rowIndex}>
               {readOnly || (
-                <td className={styles.toolCell} data-tool-cell={true}>
+                <CellElement className={styles.toolCell} data-tool-cell={true}>
                   <RowEditor {...{ setActiveCellWithBoundaries, parentEditor, rowIndex, highlightedCoordinates, lexicalTable }} />
-                </td>
+                </CellElement>
               )}
               {row.children.map((mdastCell, colIndex) => {
                 return (
@@ -298,8 +312,11 @@ const Cell: React.FC<Omit<CellProps, 'focus'>> = ({ align, ...props }) => {
   const isActive = Boolean(activeCell && activeCell[0] === props.colIndex && activeCell[1] === props.rowIndex)
 
   const className = AlignToTailwindClassMap[align || 'left']
+
+  const CellElement = getCellType(props.rowIndex)
+
   return (
-    <td
+    <CellElement
       className={className}
       data-active={isActive}
       onClick={() => {
@@ -307,7 +324,7 @@ const Cell: React.FC<Omit<CellProps, 'focus'>> = ({ align, ...props }) => {
       }}
     >
       <CellEditor {...props} focus={isActive} />
-    </td>
+    </CellElement>
   )
 }
 

--- a/src/styles/ui.module.css
+++ b/src/styles/ui.module.css
@@ -672,7 +672,8 @@
     text-align: right;
   }
 
-  &>tbody>tr>td:not(.toolCell) {
+  &>tbody>tr>td:not(.toolCell),
+  &>tbody>tr>th:not(.toolCell):not(:last-of-type) {
     border: 1px solid var(--baseBgActive);
     padding: var(--spacing-1) var(--spacing-2);
     white-space: normal;


### PR DESCRIPTION
### Description
This is a PR to fix issue https://github.com/mdx-editor/editor/issues/411

Replacing `td` with `th` element in the table editor to provide some visual difference.

### Screenshots
#### Before
<img width="1504" alt="image" src="https://github.com/mdx-editor/editor/assets/6714127/03d3d8f9-8c76-40fb-8872-44d924814d68">

#### After

<img width="1505" alt="image" src="https://github.com/mdx-editor/editor/assets/6714127/e03f2c84-b48a-4054-b77f-42417b38c36e">

### Test steps
1. Pull down the branch
2. Run `npm run dev`
3. Navigate to http://localhost:61000/?story=basics--table
4. Confirm that the header looks as per screenshot
5. Confirm you can add rows after and before the header