### PR TITLE
fix: ignore :hover css style on touch devices.

### DIFF
--- a/src/styles/ui.module.css
+++ b/src/styles/ui.module.css
@@ -20,8 +20,10 @@
     display: block;
   }
 
-  &:hover {
-    background-color: var(--baseBgHover);
+  @media (hover: hover) {
+    &:hover {
+      background-color: var(--baseBgHover);
+    }
   }
 
   &:active svg {
@@ -223,8 +225,10 @@
     display: block;
   }
 
-  &:hover {
-    background-color: var(--baseBgActive);
+  @media (hover: hover) {
+    &:hover {
+      background-color: var(--baseBgActive);
+    }
   }
 
   &:active svg {
@@ -451,8 +455,10 @@
   @mixin clear-form-element;
   color: var(--baseText);
 
-  &:hover {
-    color: var(--accentText);
+  @media (hover: hover) {
+    &:hover {
+      color: var(--accentText);
+    }
   }
 
   &:disabled,
@@ -659,9 +665,11 @@
   background-color: var(--accentSolid);
   color: var(--baseBase);
 
-  &:hover {
-    background-color: var(--accentSolidHover);
-    color: var(--baseBase);
+  @media (hover: hover) {
+    &:hover {
+      background-color: var(--accentSolidHover);
+      color: var(--baseBase);
+    }
   }
 }
 
@@ -703,17 +711,19 @@
     opacity: .15;
   }
 
-  &:hover {
+  @media (hover: hover) {
+    &:hover {
 
-    .tableColumnEditorTrigger,
-    .tableRowEditorTrigger,
-    .addRowButton,
-    .addColumnButton,
-    .iconButton {
-      opacity: 0.3;
+      .tableColumnEditorTrigger,
+      .tableRowEditorTrigger,
+      .addRowButton,
+      .addColumnButton,
+      .iconButton {
+        opacity: 0.3;
 
-      &:hover {
-        opacity: 1;
+        &:hover {
+          opacity: 1;
+        }
       }
     }
   }


### PR DESCRIPTION
Using iOS safari, if I open an mdx-editor page and do the following:

1. select the bold option
2. deselect the bold option

The result will be the bold option appears to be selected because its "hover" styling has been triggered. This is a common issue with touch devices that do not support hover. This change gates :hover behind media queries that filter only for devices that support it.