### PR TITLE
Fix updating of table inside nested editor

### DIFF
--- a/src/plugins/table/TableEditor.tsx
+++ b/src/plugins/table/TableEditor.tsx
@@ -378,9 +378,13 @@ const CellEditor: React.FC<CellProps> = ({ focus, setActiveCell, parentEditor, l
           visitors: exportVisitors,
           jsxIsAvailable
         })
-        parentEditor.update(() => {
-          lexicalTable.updateCellContents(colIndex, rowIndex, (mdast.children[0] as Mdast.Paragraph).children)
-        })
+        parentEditor.update(
+          () => {
+            lexicalTable.updateCellContents(colIndex, rowIndex, (mdast.children[0] as Mdast.Paragraph).children)
+          },
+          { discrete: true }
+        )
+        parentEditor.dispatchCommand(NESTED_EDITOR_UPDATED_COMMAND, undefined)
       })
 
       setActiveCell(nextCell)


### PR DESCRIPTION
This is a fix for issue #451 

If the table propagates the `NESTED_EDITOR_UPDATED_COMMAND` in the same way as the `NestedLexicalEditor`, it can update correctly when inside one. This also requires the table's `parentEditor.update` to be discrete like the update in `NestedLexicalEditor` so any parent editors get the newly updated table when they update.