### PR TITLE
fix(deps): fix micromark-extension-gfm-strikethrough not being externalised

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -6,7 +6,7 @@ module.exports = {
     project: ['./tsconfig.json'],
     sourceType: 'module'
   },
-  plugins: ['react', '@typescript-eslint', 'json', 'html'],
+  plugins: ['react', '@typescript-eslint', 'json', 'html', 'import'],
   env: {
     browser: true,
     es2021: true,
@@ -28,6 +28,7 @@ module.exports = {
     }
   ],
   rules: {
+    'import/no-extraneous-dependencies': ['error'],
     '@typescript-eslint/no-non-null-assertion': 'off',
     '@typescript-eslint/no-explicit-any': 'off',
     '@typescript-eslint/no-unsafe-return': 'off',

--- a/package-lock.json
+++ b/package-lock.json
@@ -50,6 +50,7 @@
         "mdast-util-to-markdown": "^2.1.0",
         "micromark-extension-directive": "^3.0.0",
         "micromark-extension-frontmatter": "^2.0.0",
+        "micromark-extension-gfm-strikethrough": "^2.0.0",
         "micromark-extension-gfm-table": "^2.0.0",
         "micromark-extension-gfm-task-list-item": "^2.0.1",
         "micromark-extension-mdx-jsx": "^3.0.0",
@@ -14414,7 +14415,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/micromark-extension-gfm-strikethrough/-/micromark-extension-gfm-strikethrough-2.0.0.tgz",
       "integrity": "sha512-c3BR1ClMp5fxxmwP6AoOY2fXO9U8uFMKs4ADD66ahLTNcwzSCyRVU4k7LPV5Nxo/VJiR4TdzxRQY2v3qIUceCw==",
-      "dev": true,
       "dependencies": {
         "devlop": "^1.0.0",
         "micromark-util-chunked": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
     "mdast-util-to-markdown": "^2.1.0",
     "micromark-extension-directive": "^3.0.0",
     "micromark-extension-frontmatter": "^2.0.0",
+    "micromark-extension-gfm-strikethrough": "^2.0.0",
     "micromark-extension-gfm-table": "^2.0.0",
     "micromark-extension-gfm-task-list-item": "^2.0.1",
     "micromark-extension-mdx-jsx": "^3.0.0",


### PR DESCRIPTION
### Description
This should fix https://github.com/mdx-editor/editor/issues/481

When running the build, you can see this import in the compiled file. This is wrong.

<img width="1121" alt="image" src="https://github.com/mdx-editor/editor/assets/6714127/caae348d-d744-4cfc-a1d2-f4e7e8ed2235">


- also add eslint rules to prevent this from happening again
- With the eslint rule on, you can see before screenshot. After making imports explicit in package json

### Before
<img width="894" alt="Screenshot 2024-06-06 at 4 52 02 PM" src="https://github.com/mdx-editor/editor/assets/6714127/135d408b-e20b-4d05-9d0e-862aff700df3">

### After
<img width="1011" alt="Screenshot 2024-06-06 at 4 53 24 PM" src="https://github.com/mdx-editor/editor/assets/6714127/1aecf54e-f734-4a34-9fe4-18245986b411">
