### PR TITLE
additional translations in pt-br

### DIFF
--- a/locales/pt-br/translation.json
+++ b/locales/pt-br/translation.json
@@ -84,7 +84,10 @@
     "checkList": "Checklist",
     "deleteSandpack": "Deletar esse bloco de código",
     "undo": "Desfazer {{shortcut}}",
-    "redo": "Refazer {{shortcut}}"
+    "redo": "Refazer {{shortcut}}",
+    "superscript": "Sobrescrito",
+    "subscript": "Subscrito",
+    "strikethrough": "Riscado"
   },
   "admonitions": {
     "note": "Nota",


### PR DESCRIPTION
The following translations were added to the pt-br.json locale file:
- toolbar.superscript: "Sobrescrito"
- toolbar.subscript: "Subescrito"
- toolbar.strikethrough: "Riscado"