### PR TITLE
Fix NestedLexicalEditor focus and update from within TableCell

### DIFF
--- a/src/plugins/core/NestedLexicalEditor.tsx
+++ b/src/plugins/core/NestedLexicalEditor.tsx
@@ -13,7 +13,8 @@ import {
   KEY_BACKSPACE_COMMAND,
   LexicalEditor,
   SELECTION_CHANGE_COMMAND,
-  createEditor
+  createEditor,
+  COMMAND_PRIORITY_LOW
 } from 'lexical'
 import * as Mdast from 'mdast'
 import { Node } from 'unist'
@@ -265,9 +266,9 @@ export const NestedLexicalEditor = function <T extends Mdast.RootContent>(props:
         FOCUS_COMMAND,
         () => {
           setEditorInFocus({ editorType: 'lexical', rootNode: lexicalNode })
-          return true
+          return false
         },
-        COMMAND_PRIORITY_EDITOR
+        COMMAND_PRIORITY_LOW
       ),
       editor.registerCommand(
         BLUR_COMMAND,

--- a/src/plugins/core/NestedLexicalEditor.tsx
+++ b/src/plugins/core/NestedLexicalEditor.tsx
@@ -4,6 +4,7 @@ import {
   $getNodeByKey,
   $getRoot,
   BLUR_COMMAND,
+  FOCUS_COMMAND,
   COMMAND_PRIORITY_CRITICAL,
   COMMAND_PRIORITY_EDITOR,
   COMMAND_PRIORITY_HIGH,
@@ -260,6 +261,14 @@ export const NestedLexicalEditor = function <T extends Mdast.RootContent>(props:
       })
     }
     return mergeRegister(
+      editor.registerCommand(
+        FOCUS_COMMAND,
+        () => {
+          setEditorInFocus({ editorType: 'lexical', rootNode: lexicalNode })
+          return true
+        },
+        COMMAND_PRIORITY_EDITOR
+      ),
       editor.registerCommand(
         BLUR_COMMAND,
         (payload) => {

--- a/src/plugins/table/TableEditor.tsx
+++ b/src/plugins/table/TableEditor.tsx
@@ -8,6 +8,7 @@ import {
   $getRoot,
   BLUR_COMMAND,
   COMMAND_PRIORITY_CRITICAL,
+  COMMAND_PRIORITY_EDITOR,
   COMMAND_PRIORITY_LOW,
   FOCUS_COMMAND,
   KEY_ENTER_COMMAND,
@@ -443,7 +444,7 @@ const CellEditor: React.FC<CellProps> = ({ focus, setActiveCell, parentEditor, l
           saveAndFocus(null)
           return true
         },
-        COMMAND_PRIORITY_CRITICAL
+        COMMAND_PRIORITY_EDITOR
       ),
 
       editor.registerCommand(


### PR DESCRIPTION
Provides a suggested fix for #528 

Adds a focus command listener to NestedLexicalEditor to prevent this event being captured by TableCell instead.

Lowers the priority of the blur command on TableCell to match NestedLexicalEditor.