### PR TITLE
Added disableImageUpload to imagePlugin

### DIFF
--- a/src/examples/images.tsx
+++ b/src/examples/images.tsx
@@ -208,7 +208,7 @@ export function ImageDialogUploadDisabled() {
   return (
     <>
       <MDXEditor
-        markdown=""
+        markdown={markdownWithHtmlImages}
         plugins={[
           imagePlugin({
             disableImageResize: true,

--- a/src/examples/images.tsx
+++ b/src/examples/images.tsx
@@ -203,3 +203,25 @@ export function ImageDialogButtonExample() {
     </>
   )
 }
+
+export function ImageDialogUploadDisabled() {
+  return (
+    <>
+      <MDXEditor
+        markdown=""
+        plugins={[
+          imagePlugin({
+            disableImageResize: true,
+            disableImageUpload: true,
+            imageUploadHandler: async () => Promise.resolve('https://picsum.photos/200/300?grayscale'),
+            imageAutocompleteSuggestions: ['https://via.placeholder.com/150', 'https://via.placeholder.com/250']
+          }),
+          diffSourcePlugin(),
+          jsxPlugin(),
+          toolbarPlugin({ toolbarContents: () => <InsertImage /> })
+        ]}
+        onChange={console.log}
+      />
+    </>
+  )
+}

--- a/src/plugins/image/ImageDialog.tsx
+++ b/src/plugins/image/ImageDialog.tsx
@@ -4,7 +4,7 @@ import React from 'react'
 import { useForm } from 'react-hook-form'
 import styles from '../../styles/ui.module.css'
 import { editorRootElementRef$, useTranslation } from '../core/index'
-import { closeImageDialog$, imageAutocompleteSuggestions$, imageDialogState$, saveImage$ } from './index'
+import { closeImageDialog$, imageAutocompleteSuggestions$, disableImageUpload$, imageDialogState$, saveImage$ } from './index'
 import { DownshiftAutoComplete } from '../core/ui/DownshiftAutoComplete'
 import { useCellValues, usePublisher } from '@mdxeditor/gurx'
 
@@ -16,8 +16,9 @@ interface ImageFormFields {
 }
 
 export const ImageDialog: React.FC = () => {
-  const [imageAutocompleteSuggestions, state, editorRootElementRef] = useCellValues(
+  const [imageAutocompleteSuggestions, disableImageUpload, state, editorRootElementRef] = useCellValues(
     imageAutocompleteSuggestions$,
+    disableImageUpload$,
     imageDialogState$,
     editorRootElementRef$
   )
@@ -57,13 +58,17 @@ export const ImageDialog: React.FC = () => {
             }}
             className={styles.multiFieldForm}
           >
-            <div className={styles.formField}>
-              <label htmlFor="file">{t('uploadImage.uploadInstructions', 'Upload an image from your device:')}</label>
-              <input type="file" accept="image/*" {...register('file')} />
-            </div>
+            {!disableImageUpload && (
+              <div className={styles.formField}>
+                <label htmlFor="file">{t('uploadImage.uploadInstructions', 'Upload an image from your device:')}</label>
+                <input type="file" accept="image/*" {...register('file')} />
+              </div>
+            )}
 
             <div className={styles.formField}>
-              <label htmlFor="src">{t('uploadImage.addViaUrlInstructions', 'Or add an image from an URL:')}</label>
+              <label htmlFor="src">
+                {t('uploadImage.addViaUrlInstructions', disableImageUpload ? 'Add an image from an URL:' : 'Or add an image from an URL:')}
+              </label>
               <DownshiftAutoComplete
                 register={register}
                 initialInputValue={state.type === 'editing' ? state.initialValues.src ?? '' : ''}

--- a/src/plugins/image/index.ts
+++ b/src/plugins/image/index.ts
@@ -242,7 +242,7 @@ export const imageDialogState$ = Cell<InactiveImageDialogState | NewImageDialogS
         editor.registerCommand<DragEvent>(
           DROP_COMMAND,
           (event) => {
-            return onDrop(event, editor, r.getValue(imageUploadHandler$), r.getValue(disableImageUpload$))
+            return onDrop(event, editor, r.getValue(imageUploadHandler$))
           },
           COMMAND_PRIORITY_HIGH
         ),
@@ -423,12 +423,12 @@ function onDragover(event: DragEvent): boolean {
   return true
 }
 
-function onDrop(event: DragEvent, editor: LexicalEditor, imageUploadHandler: ImageUploadHandler, disableImageUpload: boolean): boolean {
+function onDrop(event: DragEvent, editor: LexicalEditor, imageUploadHandler: ImageUploadHandler): boolean {
   let cbPayload = Array.from(event.dataTransfer?.items ?? [])
   cbPayload = cbPayload.filter((i) => i.type.includes('image')) // Strip out the non-image bits
 
   if (cbPayload.length > 0) {
-    if (imageUploadHandler !== null && !disableImageUpload) {
+    if (imageUploadHandler !== null) {
       event.preventDefault()
       Promise.all(cbPayload.map((image) => imageUploadHandler(image.getAsFile()!)))
         .then((urls) => {


### PR DESCRIPTION
Configuration flag for `imagePlugin` to disable image upload. Ideal for projects that are not self-hosting images.

NOTE: One further improvement to this PR would be to eliminate the `dropEffect` when an outside image is brought onto the page.