### PR TITLE
Export default icons for toolbar customization

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -33,6 +33,7 @@ import './styles/globals.css'
 export * from '@mdxeditor/gurx'
 // editor component
 export * from './MDXEditor'
+export * from './defaultSvgIcons'
 
 // import/export
 export * from './importMarkdownToLexical'


### PR DESCRIPTION
Provide a fix for the #545

Export both `IconKey` type (to use in the `iconComponentFor` prop) and the `defaultSvgIcons` constant to override icons properly