### PR TITLE
read-only mode -> in table -> in first row -> only last cell doesn't …

### DIFF
--- a/src/styles/ui.module.css
+++ b/src/styles/ui.module.css
@@ -722,7 +722,7 @@
   }
 
   &>tbody>tr>td:not(.toolCell),
-  &>tbody>tr>th:not(.toolCell):not(:last-of-type) {
+  &>tbody>tr>th:not(.toolCell):not([data-tool-cell="true"]) {
     border: 1px solid var(--baseBgActive);
     padding: var(--spacing-1) var(--spacing-2);
     white-space: normal;


### PR DESCRIPTION
…have border styling

Related to this issue:
https://github.com/mdx-editor/editor/issues/532

Next one which I'm going to fix is displaying line breaks properly in Read Only mode