### PR TITLE
feat: add `hideImageToolbar` option to imagePlugin

### DIFF
--- a/src/plugins/image/ImageEditor.tsx
+++ b/src/plugins/image/ImageEditor.tsx
@@ -271,42 +271,44 @@ export function ImageEditor({ src, title, alt, nodeKey, width, height }: ImageEd
         {draggable && isFocused && !disableImageResize && (
           <ImageResizer editor={editor} imageRef={imageRef} onResizeStart={onResizeStart} onResizeEnd={onResizeEnd} />
         )}
-        <div className={styles.editImageToolbar}>
-          <button
-            className={styles.iconButton}
-            type="button"
-            title={t('image.delete', 'Delete image')}
-            disabled={readOnly}
-            onClick={(e) => {
-              e.preventDefault()
-              editor.update(() => {
-                $getNodeByKey(nodeKey)?.remove()
-              })
-            }}
-          >
-            {iconComponentFor('delete_small')}
-          </button>
-          {!disableImageSettingsButton && (
+        {readOnly || (
+          <div className={styles.editImageToolbar}>
             <button
+              className={styles.iconButton}
               type="button"
-              className={classNames(styles.iconButton, styles.editImageButton)}
-              title={t('imageEditor.editImage', 'Edit image')}
+              title={t('image.delete', 'Delete image')}
               disabled={readOnly}
-              onClick={() => {
-                openEditImageDialog({
-                  nodeKey: nodeKey,
-                  initialValues: {
-                    src: !initialImagePath ? imageSource : initialImagePath,
-                    title: title ?? '',
-                    altText: alt ?? ''
-                  }
+              onClick={(e) => {
+                e.preventDefault()
+                editor.update(() => {
+                  $getNodeByKey(nodeKey)?.remove()
                 })
               }}
             >
-              {iconComponentFor('settings')}
+              {iconComponentFor('delete_small')}
             </button>
-          )}
-        </div>
+            {!disableImageSettingsButton && (
+              <button
+                type="button"
+                className={classNames(styles.iconButton, styles.editImageButton)}
+                title={t('imageEditor.editImage', 'Edit image')}
+                disabled={readOnly}
+                onClick={() => {
+                  openEditImageDialog({
+                    nodeKey: nodeKey,
+                    initialValues: {
+                      src: !initialImagePath ? imageSource : initialImagePath,
+                      title: title ?? '',
+                      altText: alt ?? ''
+                    }
+                  })
+                }}
+              >
+                {iconComponentFor('settings')}
+              </button>
+            )}
+          </div>
+        )}
       </div>
     </React.Suspense>
   ) : null

--- a/src/plugins/image/ImageEditor.tsx
+++ b/src/plugins/image/ImageEditor.tsx
@@ -20,7 +20,7 @@ import {
   KEY_ESCAPE_COMMAND,
   SELECTION_CHANGE_COMMAND
 } from 'lexical'
-import { disableImageResize$, disableImageSettingsButton$, imagePreviewHandler$, openEditImageDialog$, hideImageToolbar$ } from '.'
+import { disableImageResize$, disableImageSettingsButton$, imagePreviewHandler$, openEditImageDialog$ } from '.'
 import styles from '../../styles/ui.module.css'
 import { iconComponentFor$, readOnly$, useTranslation } from '../core'
 import { $isImageNode } from './ImageNode'
@@ -85,13 +85,12 @@ function LazyImage({
 }
 
 export function ImageEditor({ src, title, alt, nodeKey, width, height }: ImageEditorProps): JSX.Element | null {
-  const [disableImageResize, disableImageSettingsButton, imagePreviewHandler, iconComponentFor, readOnly, hideImageToolbar] = useCellValues(
+  const [disableImageResize, disableImageSettingsButton, imagePreviewHandler, iconComponentFor, readOnly] = useCellValues(
     disableImageResize$,
     disableImageSettingsButton$,
     imagePreviewHandler$,
     iconComponentFor$,
-    readOnly$,
-    hideImageToolbar$
+    readOnly$
   )
 
   const openEditImageDialog = usePublisher(openEditImageDialog$)
@@ -272,44 +271,42 @@ export function ImageEditor({ src, title, alt, nodeKey, width, height }: ImageEd
         {draggable && isFocused && !disableImageResize && (
           <ImageResizer editor={editor} imageRef={imageRef} onResizeStart={onResizeStart} onResizeEnd={onResizeEnd} />
         )}
-        {!hideImageToolbar && (
-          <div className={styles.editImageToolbar}>
+        <div className={styles.editImageToolbar}>
+          <button
+            className={styles.iconButton}
+            type="button"
+            title={t('image.delete', 'Delete image')}
+            disabled={readOnly}
+            onClick={(e) => {
+              e.preventDefault()
+              editor.update(() => {
+                $getNodeByKey(nodeKey)?.remove()
+              })
+            }}
+          >
+            {iconComponentFor('delete_small')}
+          </button>
+          {!disableImageSettingsButton && (
             <button
-              className={styles.iconButton}
               type="button"
-              title={t('image.delete', 'Delete image')}
+              className={classNames(styles.iconButton, styles.editImageButton)}
+              title={t('imageEditor.editImage', 'Edit image')}
               disabled={readOnly}
-              onClick={(e) => {
-                e.preventDefault()
-                editor.update(() => {
-                  $getNodeByKey(nodeKey)?.remove()
+              onClick={() => {
+                openEditImageDialog({
+                  nodeKey: nodeKey,
+                  initialValues: {
+                    src: !initialImagePath ? imageSource : initialImagePath,
+                    title: title ?? '',
+                    altText: alt ?? ''
+                  }
                 })
               }}
             >
-              {iconComponentFor('delete_small')}
+              {iconComponentFor('settings')}
             </button>
-            {!disableImageSettingsButton && (
-              <button
-                type="button"
-                className={classNames(styles.iconButton, styles.editImageButton)}
-                title={t('imageEditor.editImage', 'Edit image')}
-                disabled={readOnly}
-                onClick={() => {
-                  openEditImageDialog({
-                    nodeKey: nodeKey,
-                    initialValues: {
-                      src: !initialImagePath ? imageSource : initialImagePath,
-                      title: title ?? '',
-                      altText: alt ?? ''
-                    }
-                  })
-                }}
-              >
-                {iconComponentFor('settings')}
-              </button>
-            )}
-          </div>
-        )}
+          )}
+        </div>
       </div>
     </React.Suspense>
   ) : null

--- a/src/plugins/image/ImageEditor.tsx
+++ b/src/plugins/image/ImageEditor.tsx
@@ -20,7 +20,7 @@ import {
   KEY_ESCAPE_COMMAND,
   SELECTION_CHANGE_COMMAND
 } from 'lexical'
-import { disableImageResize$, disableImageSettingsButton$, imagePreviewHandler$, openEditImageDialog$ } from '.'
+import { disableImageResize$, disableImageSettingsButton$, imagePreviewHandler$, openEditImageDialog$, hideImageToolbar$ } from '.'
 import styles from '../../styles/ui.module.css'
 import { iconComponentFor$, readOnly$, useTranslation } from '../core'
 import { $isImageNode } from './ImageNode'
@@ -85,12 +85,13 @@ function LazyImage({
 }
 
 export function ImageEditor({ src, title, alt, nodeKey, width, height }: ImageEditorProps): JSX.Element | null {
-  const [disableImageResize, disableImageSettingsButton, imagePreviewHandler, iconComponentFor, readOnly] = useCellValues(
+  const [disableImageResize, disableImageSettingsButton, imagePreviewHandler, iconComponentFor, readOnly, hideImageToolbar] = useCellValues(
     disableImageResize$,
     disableImageSettingsButton$,
     imagePreviewHandler$,
     iconComponentFor$,
-    readOnly$
+    readOnly$,
+    hideImageToolbar$
   )
 
   const openEditImageDialog = usePublisher(openEditImageDialog$)
@@ -271,42 +272,44 @@ export function ImageEditor({ src, title, alt, nodeKey, width, height }: ImageEd
         {draggable && isFocused && !disableImageResize && (
           <ImageResizer editor={editor} imageRef={imageRef} onResizeStart={onResizeStart} onResizeEnd={onResizeEnd} />
         )}
-        <div className={styles.editImageToolbar}>
-          <button
-            className={styles.iconButton}
-            type="button"
-            title={t('image.delete', 'Delete image')}
-            disabled={readOnly}
-            onClick={(e) => {
-              e.preventDefault()
-              editor.update(() => {
-                $getNodeByKey(nodeKey)?.remove()
-              })
-            }}
-          >
-            {iconComponentFor('delete_small')}
-          </button>
-          {!disableImageSettingsButton && (
+        {!hideImageToolbar && (
+          <div className={styles.editImageToolbar}>
             <button
+              className={styles.iconButton}
               type="button"
-              className={classNames(styles.iconButton, styles.editImageButton)}
-              title={t('imageEditor.editImage', 'Edit image')}
+              title={t('image.delete', 'Delete image')}
               disabled={readOnly}
-              onClick={() => {
-                openEditImageDialog({
-                  nodeKey: nodeKey,
-                  initialValues: {
-                    src: !initialImagePath ? imageSource : initialImagePath,
-                    title: title ?? '',
-                    altText: alt ?? ''
-                  }
+              onClick={(e) => {
+                e.preventDefault()
+                editor.update(() => {
+                  $getNodeByKey(nodeKey)?.remove()
                 })
               }}
             >
-              {iconComponentFor('settings')}
+              {iconComponentFor('delete_small')}
             </button>
-          )}
-        </div>
+            {!disableImageSettingsButton && (
+              <button
+                type="button"
+                className={classNames(styles.iconButton, styles.editImageButton)}
+                title={t('imageEditor.editImage', 'Edit image')}
+                disabled={readOnly}
+                onClick={() => {
+                  openEditImageDialog({
+                    nodeKey: nodeKey,
+                    initialValues: {
+                      src: !initialImagePath ? imageSource : initialImagePath,
+                      title: title ?? '',
+                      altText: alt ?? ''
+                    }
+                  })
+                }}
+              >
+                {iconComponentFor('settings')}
+              </button>
+            )}
+          </div>
+        )}
       </div>
     </React.Suspense>
   ) : null

--- a/src/plugins/image/index.ts
+++ b/src/plugins/image/index.ts
@@ -175,20 +175,20 @@ export const imageDialogState$ = Cell<InactiveImageDialogState | NewImageDialogS
         const handler =
           dialogState.type === 'editing'
             ? (src: string) => {
-              theEditor?.update(() => {
-                const { nodeKey } = dialogState
-                const imageNode = $getNodeByKey(nodeKey)! as ImageNode
+                theEditor?.update(() => {
+                  const { nodeKey } = dialogState
+                  const imageNode = $getNodeByKey(nodeKey)! as ImageNode
 
-                imageNode.setTitle(values.title)
-                imageNode.setAltText(values.altText)
-                imageNode.setSrc(src)
-              })
-              r.pub(imageDialogState$, { type: 'inactive' })
-            }
+                  imageNode.setTitle(values.title)
+                  imageNode.setAltText(values.altText)
+                  imageNode.setSrc(src)
+                })
+                r.pub(imageDialogState$, { type: 'inactive' })
+              }
             : (src: string) => {
-              r.pub(internalInsertImage$, { ...values, src })
-              r.pub(imageDialogState$, { type: 'inactive' })
-            }
+                r.pub(internalInsertImage$, { ...values, src })
+                r.pub(imageDialogState$, { type: 'inactive' })
+              }
 
         if (values.file.length > 0) {
           imageUploadHandler?.(values.file.item(0)!)
@@ -315,8 +315,6 @@ export const closeImageDialog$ = Action((r) => {
 
 export const disableImageSettingsButton$ = Cell<boolean>(false)
 
-export const hideImageToolbar$ = Cell<boolean>(false)
-
 /**
  * Saves the data from the image dialog
  * @group Image
@@ -332,7 +330,6 @@ export const imagePlugin = realmPlugin<{
   imageAutocompleteSuggestions?: string[]
   disableImageResize?: boolean
   disableImageSettingsButton?: boolean
-  hideImageToolbar?: boolean
   imagePreviewHandler?: ImagePreviewHandler
   ImageDialog?: (() => JSX.Element) | React.FC
 }>({
@@ -346,7 +343,6 @@ export const imagePlugin = realmPlugin<{
       [imageAutocompleteSuggestions$]: params?.imageAutocompleteSuggestions ?? [],
       [disableImageResize$]: Boolean(params?.disableImageResize),
       [disableImageSettingsButton$]: Boolean(params?.disableImageSettingsButton),
-      [hideImageToolbar$]: Boolean(params?.hideImageToolbar),
       [imagePreviewHandler$]: params?.imagePreviewHandler ?? null
     })
   },

--- a/src/plugins/image/index.ts
+++ b/src/plugins/image/index.ts
@@ -175,20 +175,20 @@ export const imageDialogState$ = Cell<InactiveImageDialogState | NewImageDialogS
         const handler =
           dialogState.type === 'editing'
             ? (src: string) => {
-                theEditor?.update(() => {
-                  const { nodeKey } = dialogState
-                  const imageNode = $getNodeByKey(nodeKey)! as ImageNode
+              theEditor?.update(() => {
+                const { nodeKey } = dialogState
+                const imageNode = $getNodeByKey(nodeKey)! as ImageNode
 
-                  imageNode.setTitle(values.title)
-                  imageNode.setAltText(values.altText)
-                  imageNode.setSrc(src)
-                })
-                r.pub(imageDialogState$, { type: 'inactive' })
-              }
+                imageNode.setTitle(values.title)
+                imageNode.setAltText(values.altText)
+                imageNode.setSrc(src)
+              })
+              r.pub(imageDialogState$, { type: 'inactive' })
+            }
             : (src: string) => {
-                r.pub(internalInsertImage$, { ...values, src })
-                r.pub(imageDialogState$, { type: 'inactive' })
-              }
+              r.pub(internalInsertImage$, { ...values, src })
+              r.pub(imageDialogState$, { type: 'inactive' })
+            }
 
         if (values.file.length > 0) {
           imageUploadHandler?.(values.file.item(0)!)
@@ -315,6 +315,8 @@ export const closeImageDialog$ = Action((r) => {
 
 export const disableImageSettingsButton$ = Cell<boolean>(false)
 
+export const hideImageToolbar$ = Cell<boolean>(false)
+
 /**
  * Saves the data from the image dialog
  * @group Image
@@ -330,6 +332,7 @@ export const imagePlugin = realmPlugin<{
   imageAutocompleteSuggestions?: string[]
   disableImageResize?: boolean
   disableImageSettingsButton?: boolean
+  hideImageToolbar?: boolean
   imagePreviewHandler?: ImagePreviewHandler
   ImageDialog?: (() => JSX.Element) | React.FC
 }>({
@@ -343,6 +346,7 @@ export const imagePlugin = realmPlugin<{
       [imageAutocompleteSuggestions$]: params?.imageAutocompleteSuggestions ?? [],
       [disableImageResize$]: Boolean(params?.disableImageResize),
       [disableImageSettingsButton$]: Boolean(params?.disableImageSettingsButton),
+      [hideImageToolbar$]: Boolean(params?.hideImageToolbar),
       [imagePreviewHandler$]: params?.imagePreviewHandler ?? null
     })
   },


### PR DESCRIPTION
Make it possible to hide the image toolbar, e.g. when editor is in readOnly mode.

When using the editor to just render documents (e.g. in an application where some users only have viewing capabilities), even with hidden toolbar and read only mode, each image will still show the toolbar (settings + delete icon). Other plugins, like the table, hide their toolbar already when in read only mode. This makes it possible to get to the same state with the image plugin, alternatively, it could also make sense to always hide the toolbar when in read only mode.