### PR TITLE
Reduce update command priority on Table Cell

### DIFF
--- a/src/plugins/table/TableEditor.tsx
+++ b/src/plugins/table/TableEditor.tsx
@@ -453,7 +453,7 @@ const CellEditor: React.FC<CellProps> = ({ focus, setActiveCell, parentEditor, l
           saveAndFocus(null)
           return true
         },
-        COMMAND_PRIORITY_CRITICAL
+        COMMAND_PRIORITY_EDITOR
       )
     )
   }, [colIndex, editor, rootEditor, rowIndex, saveAndFocus, setActiveCell])


### PR DESCRIPTION
This is to address #570

Currently no other plugins have a priority higher than EDITOR for this action, so this allows the command to bubble up the hierarchy in order