### PR TITLE
Don't trim initial markdown

### DIFF
--- a/src/MDXEditor.tsx
+++ b/src/MDXEditor.tsx
@@ -279,6 +279,10 @@ export interface MDXEditorProps {
    * Pass your own translation function if you want to localize the editor.
    */
   translation?: Translation
+  /**
+   * Whether to apply trim() to the initial markdown input (default: true)
+   */
+  trim?: boolean
 }
 
 /**
@@ -301,7 +305,8 @@ export const MDXEditor = React.forwardRef<MDXEditorMethods, MDXEditorProps>((pro
           iconComponentFor: props.iconComponentFor ?? defaultIconComponentFor,
           suppressHtmlProcessing: props.suppressHtmlProcessing ?? false,
           onError: props.onError ?? noop,
-          translation: props.translation ?? defaultTranslation
+          translation: props.translation ?? defaultTranslation,
+          trim: props.trim ?? true
         }),
         ...(props.plugins ?? [])
       ]}

--- a/src/plugins/core/index.ts
+++ b/src/plugins/core/index.ts
@@ -856,7 +856,7 @@ export const corePlugin = realmPlugin<{
     r.register(createActiveEditorSubscription$)
     r.register(markdownSignal$)
     r.pubIn({
-      [initialMarkdown$]: params?.initialMarkdown.trim(),
+      [initialMarkdown$]: params?.initialMarkdown ?? '',
       [iconComponentFor$]: params?.iconComponentFor,
       [addImportVisitor$]: [MdastRootVisitor, MdastParagraphVisitor, MdastTextVisitor, MdastBreakVisitor, ...formattingVisitors],
       [addLexicalNode$]: [ParagraphNode, TextNode, GenericHTMLNode],

--- a/src/plugins/core/index.ts
+++ b/src/plugins/core/index.ts
@@ -850,13 +850,16 @@ export const corePlugin = realmPlugin<{
   iconComponentFor: (name: IconKey) => React.ReactElement
   suppressHtmlProcessing?: boolean
   translation: Translation
+  trim?: boolean
 }>({
   init(r, params) {
+    const initialMarkdown = params?.initialMarkdown ?? ''
+
     r.register(createRootEditorSubscription$)
     r.register(createActiveEditorSubscription$)
     r.register(markdownSignal$)
     r.pubIn({
-      [initialMarkdown$]: params?.initialMarkdown ?? '',
+      [initialMarkdown$]: params?.trim ? initialMarkdown.trim() : initialMarkdown,
       [iconComponentFor$]: params?.iconComponentFor,
       [addImportVisitor$]: [MdastRootVisitor, MdastParagraphVisitor, MdastTextVisitor, MdastBreakVisitor, ...formattingVisitors],
       [addLexicalNode$]: [ParagraphNode, TextNode, GenericHTMLNode],


### PR DESCRIPTION
When using diffSourcePlugin with viewmode=source, this trim() would cause MDXEditor's onChange to fire immediately. This in turn would dirty the field when used in combination with a form wrapper like
react-hook-form.

I think the initial markdown does not need to be trimmed; the user should be free to initialize the editor with trailing or leading newlines as they see fit, the editor should not care.