### PR TITLE
fix: image dialog missing title

### DIFF
--- a/locales/en/translation.json
+++ b/locales/en/translation.json
@@ -10,6 +10,7 @@
     "cancel": "Cancel"
   },
   "uploadImage": {
+    "dialogTitle": "Upload an image",
     "uploadInstructions": "Upload an image from your device:",
     "addViaUrlInstructions": "Or add an image from an URL:",
     "autoCompletePlaceholder": "Select or paste an image src",

--- a/locales/es-es/translation.json
+++ b/locales/es-es/translation.json
@@ -10,6 +10,7 @@
     "cancel": "Cancelar"
   },
   "uploadImage": {
+    "dialogTitle": "Subir una imágen",
     "uploadInstructions": "Sube una imágen desde tu dispositivo:",
     "addViaUrlInstructions": "O añade una imágen desde una URL:",
     "autoCompletePlaceholder": "Selecciona o pega el src de la imágen",

--- a/locales/pt-br/translation.json
+++ b/locales/pt-br/translation.json
@@ -10,6 +10,7 @@
     "cancel": "Cancelar"
   },
   "uploadImage": {
+    "dialogTitle": "Enviar uma imagem",
     "uploadInstructions": "Enviar uma imagem do seu dispotivo:",
     "addViaUrlInstructions": "Ou adicionar uma imagem a partir de um URL:",
     "autoCompletePlaceholder": "Insira um link de imagem",

--- a/locales/uk-ua/translation.json
+++ b/locales/uk-ua/translation.json
@@ -10,6 +10,7 @@
       "cancel": "Скасувати"
     },
     "uploadImage": {
+      "dialogTitle": "Завантажити зображення",
       "uploadInstructions": "Завантажте зображення з вашого пристрою:",
       "addViaUrlInstructions": "Або додайте зображення з URL посилання:",
       "autoCompletePlaceholder": "Виберіть або вставте джерело зображення",

--- a/locales/zh-cn/translation.json
+++ b/locales/zh-cn/translation.json
@@ -10,6 +10,7 @@
     "cancel": "取消"
   },
   "uploadImage": {
+    "dialogTitle": "上传图片",
     "uploadInstructions": "从您的设备中上传图片：",
     "addViaUrlInstructions": "或从网址新增图片：",
     "autoCompletePlaceholder": "选择或粘贴图片",

--- a/locales/zh-tw/translation.json
+++ b/locales/zh-tw/translation.json
@@ -10,6 +10,7 @@
     "cancel": "取消"
   },
   "uploadImage": {
+    "dialogTitle": "上傳圖片",
     "uploadInstructions": "從您的裝置上傳圖片：",
     "addViaUrlInstructions": "或從網址新增圖片：",
     "autoCompletePlaceholder": "選擇或貼上圖片網址",

--- a/src/plugins/image/ImageDialog.tsx
+++ b/src/plugins/image/ImageDialog.tsx
@@ -49,6 +49,7 @@ export const ImageDialog: React.FC = () => {
             e.preventDefault()
           }}
         >
+          <Dialog.Title>{t('uploadImage.dialogTitle', 'Upload an image')}</Dialog.Title>
           <form
             onSubmit={(e) => {
               void handleSubmit(saveImage)(e)


### PR DESCRIPTION
Due to the changes made by the radix (and screen readers API). Using `ImageDialog` without `Dialog.Title` component will result in errors in the console. 

I have also added the translations to keep everything up-to-date.
