### PR TITLE
Docs - Getting Started - Next.js (App) - missing imports

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -69,6 +69,8 @@ export default function InitializedMDXEditor({
 ```tsx
 'use client'
 // ForwardRefEditor.tsx
+import dynamic from 'next/dynamic'
+import { forwardRef } from "react"
 
 // This is the only place InitializedMDXEditor is imported directly.
 const Editor = dynamic(() => import('./InitializedMDXEditor'), {


### PR DESCRIPTION
Was going through the nextjs installation and noticed that two imports were missing in the code snippet given. It's not a huge issue, but figured it's easier to have it on there and ready for copy-pasta.