### PR TITLE
fix: i18n key for delete image functionality

### DIFF
--- a/locales/en/translation.json
+++ b/locales/en/translation.json
@@ -18,6 +18,7 @@
     "title": "Title:"
   },
   "imageEditor": {
+    "deleteImage": "Delete image",
     "editImage": "Edit image"
   },
   "createLink": {

--- a/locales/es-es/translation.json
+++ b/locales/es-es/translation.json
@@ -18,6 +18,7 @@
     "title": "Título:"
   },
   "imageEditor": {
+    "deleteImage": "Borrar imagen",
     "editImage": "Editar imagen"
   },
   "createLink": {

--- a/locales/ko-kr/translation.json
+++ b/locales/ko-kr/translation.json
@@ -18,6 +18,7 @@
     "title": "제목:"
   },
   "imageEditor": {
+    "deleteImage": "이미지 삭제",
     "editImage": "이미지 편집"
   },
   "createLink": {

--- a/locales/pt-br/translation.json
+++ b/locales/pt-br/translation.json
@@ -18,6 +18,7 @@
     "title": "Título:"
   },
   "imageEditor": {
+    "deleteImage": "Deletar imagem",
     "editImage": "Editar imagem"
   },
   "createLink": {

--- a/locales/uk-ua/translation.json
+++ b/locales/uk-ua/translation.json
@@ -18,6 +18,7 @@
       "title": "Назва:"
     },
     "imageEditor": {
+      "deleteImage": "Видалити зображення",
       "editImage": "Редагувати зображення"
     },
     "createLink": {

--- a/locales/zh-cn/translation.json
+++ b/locales/zh-cn/translation.json
@@ -18,6 +18,7 @@
     "title": "标题："
   },
   "imageEditor": {
+    "deleteImage": "删除图片",
     "editImage": "编辑图片"
   },
   "createLink": {

--- a/locales/zh-tw/translation.json
+++ b/locales/zh-tw/translation.json
@@ -18,6 +18,7 @@
     "title": "標題："
   },
   "imageEditor": {
+    "deleteImage": "刪除圖片",
     "editImage": "編輯圖片"
   },
   "createLink": {

--- a/src/plugins/image/ImageEditor.tsx
+++ b/src/plugins/image/ImageEditor.tsx
@@ -292,7 +292,7 @@ export function ImageEditor({ src, title, alt, nodeKey, width, height, rest }: I
             <button
               className={styles.iconButton}
               type="button"
-              title={t('image.delete', 'Delete image')}
+              title={t('imageEditor.deleteImage', 'Delete image')}
               disabled={readOnly}
               onClick={(e) => {
                 e.preventDefault()


### PR DESCRIPTION
While adding support for multiple languages, I noticed that the translation for "Delete image" was not working. Upon investigation, I found that the key for "Delete image" was missing under imageEditor.

Currently, to apply the correct translation, we need to use image.delete:
```json
{
    "image": {
        "delete": "Delete image"
    },
    "imageEditor": {
        "editImage": "Edit image"
    }
}
```
Expected Update
Move the "Delete image" key under imageEditor for consistency:
```json
{
    "imageEditor": {
        "deleteImage": "Delete image",
        "editImage": "Edit image"
    }
}
```
As a non-native English speaker, I welcome any suggestions for improvement.

<img width="745" alt="image" src="https://github.com/user-attachments/assets/0723c93d-0e93-48dc-8e70-9edcb5227db0">
