### PR TITLE
Only paste as image if payload does not contain text content

### DIFF
--- a/src/plugins/image/index.ts
+++ b/src/plugins/image/index.ts
@@ -253,8 +253,9 @@ export const imageDialogState$ = Cell<InactiveImageDialogState | NewImageDialogS
               return false // If from web, bail.
             }
 
-            let cbPayload = Array.from(event.clipboardData?.items ?? [])
-            cbPayload = cbPayload.filter((i) => i.type.includes('image')) // Strip out the non-image bits
+            const cbPayload = Array.from(event.clipboardData?.items ?? [])
+            const isMixedPayload = cbPayload.some((item) => !item.type.includes('image'))
+            if (isMixedPayload) return false
 
             if (!cbPayload.length || cbPayload.length === 0) {
               return false


### PR DESCRIPTION
Currently, if you copy text from MS Word into the mdx-editor with the image plugin enabled, the content will be pasted as image. This is because MS Word (at least on a mac) adds the copied selection as plaintext, html, rtf and as *image* to the systems paste buffer. The Paste Command in the image plugin, intercepted the paste since an image was in the buffer.

This fix only allows the paste command in the image plugin to intercept the pasting if the paste buffer exclusively contains images.

Here is a video comparing the previous and the new behavior:
https://github.com/user-attachments/assets/ccc87ca7-a47d-4c79-9e78-d7d51d37f9de

