### PR TITLE
fix: linter error in src/plugins/table/index.ts 92l

### DIFF
--- a/src/plugins/table/index.ts
+++ b/src/plugins/table/index.ts
@@ -89,7 +89,10 @@ export const tablePlugin = realmPlugin<GfmTableOptions>({
       // export
       [addLexicalNode$]: TableNode,
       [addExportVisitor$]: LexicalTableVisitor,
-      [addToMarkdownExtension$]: gfmTableToMarkdown({ tableCellPadding: params?.tableCellPadding ?? true, tablePipeAlign: params?.tablePipeAlign ?? true })
+      [addToMarkdownExtension$]: gfmTableToMarkdown({
+        tableCellPadding: params?.tableCellPadding ?? true,
+        tablePipeAlign: params?.tablePipeAlign ?? true
+      })
     })
   }
 })


### PR DESCRIPTION
Fixed a Prettier formatting issue in src/plugins/table/index.ts on line 92 that caused the release pipeline to fail. 

<img width="1044" alt="image" src="https://github.com/user-attachments/assets/31981838-ed4e-479f-8854-dd00289ea2c7">
