### PR TITLE
Create onFocusPlugin

### DIFF
--- a/src/examples/on-focus-plugin.tsx
+++ b/src/examples/on-focus-plugin.tsx
@@ -1,0 +1,47 @@
+import React from 'react'
+import { onFocusPlugin } from '@/plugins/on-focus'
+import { MDXEditor } from '@/MDXEditor'
+import { toolbarPlugin } from '@/plugins/toolbar'
+import { BoldItalicUnderlineToggles } from '@/plugins/toolbar/components/BoldItalicUnderlineToggles'
+
+export function Basic() {
+  const [focused, setFocused] = React.useState(false)
+  return (
+    <div>
+      Focused: {focused ? 'true' : 'false'}
+      <MDXEditor
+        onBlur={() => {
+          setFocused(false)
+        }}
+        markdown="Click me!"
+        plugins={[
+          onFocusPlugin({
+            action: () => {
+              setFocused(true)
+            }
+          })
+        ]}
+      />
+    </div>
+  )
+}
+
+export function LoadPluginOnInitialFocus() {
+  return (
+    <div>
+      <MDXEditor
+        markdown="Click me!"
+        plugins={[
+          onFocusPlugin({
+            once: true,
+            action: (realm) => {
+              toolbarPlugin({
+                toolbarContents: () => <BoldItalicUnderlineToggles />
+              }).init?.(realm)
+            }
+          })
+        ]}
+      />
+    </div>
+  )
+}

--- a/src/plugins/on-focus/index.ts
+++ b/src/plugins/on-focus/index.ts
@@ -1,0 +1,18 @@
+import { Realm } from '@mdxeditor/gurx'
+import { realmPlugin } from '@/RealmWithPlugins'
+import { inFocus$ } from '@/plugins/core'
+
+export const onFocusPlugin = realmPlugin<{
+  action: (realm: Realm) => void
+  once?: boolean
+}>({
+  init: (realm, params) => {
+    const unsubscribe = realm.sub(inFocus$, (isFocused) => {
+      if (!isFocused) return
+      params?.action(realm)
+      if (params?.once) {
+        unsubscribe()
+      }
+    })
+  }
+})


### PR DESCRIPTION
This plugin allows for a callback to be triggered when the editor is focused.
An example is given where another plugin is loaded upon the first focus.