### PR TITLE
fix: typo in MDXEditor documentation

### DIFF
--- a/src/MDXEditor.tsx
+++ b/src/MDXEditor.tsx
@@ -234,7 +234,7 @@ export interface MDXEditorProps {
    */
   contentEditableClassName?: string
   /**
-   * Controls the spellCheck value for the content editable element of the eitor.
+   * Controls the spellCheck value for the content editable element of the editor.
    * Defaults to true, use false to disable spell checking.
    */
   spellCheck?: boolean
@@ -288,7 +288,7 @@ export interface MDXEditorProps {
    */
   iconComponentFor?: (name: IconKey) => JSX.Element
   /**
-   * Set to false if you want to suppress the processing of HTML tags.
+   * Set to true if you want to suppress the processing of HTML tags.
    */
   suppressHtmlProcessing?: boolean
   /**


### PR DESCRIPTION
Fixed typo on [MDSEditorProps documentation page](https://mdxeditor.dev/editor/api/interfaces/MDXEditorProps)

Moreover, on this page, link to `the mdast-util-to-markdown docs` is broken because it is relative. I don't know how to fix it.