### PR TITLE
fix: preserve line breaks in list items

### DIFF
--- a/src/plugins/lists/LexicalListItemVisitor.ts
+++ b/src/plugins/lists/LexicalListItemVisitor.ts
@@ -1,7 +1,7 @@
 import { $isListItemNode, $isListNode, ListItemNode, ListNode } from '@lexical/list'
 import * as Mdast from 'mdast'
 import { LexicalExportVisitor } from '../../exportMarkdownFromLexical'
-import { $isElementNode, $isTextNode, $isDecoratorNode } from 'lexical'
+import { $isElementNode, $isTextNode, $isDecoratorNode, $isLineBreakNode } from 'lexical'
 
 export const LexicalListItemVisitor: LexicalExportVisitor<ListItemNode, Mdast.ListItem> = {
   testLexicalNode: $isListItemNode,
@@ -31,7 +31,7 @@ export const LexicalListItemVisitor: LexicalExportVisitor<ListItemNode, Mdast.Li
       }) as Mdast.ListItem
       let surroundingParagraph: Mdast.Paragraph | null = null
       for (const child of lexicalNode.getChildren()) {
-        if ($isTextNode(child) || ($isElementNode(child) && child.isInline()) || ($isDecoratorNode(child) && child.isInline())) {
+        if ($isTextNode(child) || $isLineBreakNode(child) || (child.isInline() && ($isElementNode(child) || $isDecoratorNode(child)))) {
           if (!surroundingParagraph) {
             surroundingParagraph = actions.appendToParent(listItem, {
               type: 'paragraph' as const,


### PR DESCRIPTION
Fixes #706 

Other cases seem to be working fine:

![image](https://github.com/user-attachments/assets/29392015-fa4f-446a-862c-e972b777e283)

![image](https://github.com/user-attachments/assets/564fedc5-d4d5-44ea-bbf4-89d6f019a7a2)
