### PR TITLE
Add Markdown Shortcut for thematic break (HR)

### DIFF
--- a/src/plugins/markdown-shortcut/index.tsx
+++ b/src/plugins/markdown-shortcut/index.tsx
@@ -24,6 +24,11 @@ import { realmPlugin } from '../../RealmWithPlugins'
 import { $createCodeBlockNode, CodeBlockNode } from '../codeblock/CodeBlockNode'
 import { activePlugins$, addComposerChild$, addNestedEditorChild$ } from '../core'
 import { HEADING_LEVEL, allowedHeadingLevels$ } from '../headings'
+import {
+  $createHorizontalRuleNode,
+  $isHorizontalRuleNode,
+  HorizontalRuleNode
+} from '@lexical/react/LexicalHorizontalRuleNode'
 
 /**
  * A plugin that adds markdown shortcuts to the editor.
@@ -49,6 +54,20 @@ const createBlockNode = (createNode: (match: string[]) => ElementNode): ElementT
     node.select(0, 0)
   }
 }
+
+const THEMATIC_BREAK: ElementTransformer = {
+  dependencies: [HorizontalRuleNode],
+  export: (node: LexicalNode) => {
+    return $isHorizontalRuleNode(node) ? '***' : null
+  },
+  regExp: /^(---|\*\*\*|___)?/,
+  replace: (parentNode, children, match) => {
+    const node = $createHorizontalRuleNode()
+    parentNode.replace(node)
+  },
+  type: 'element'
+}
+
 
 function pickTransformersForActivePlugins(pluginIds: string[], allowedHeadingLevels: readonly HEADING_LEVEL[]) {
   const transformers: Transformer[] = [
@@ -87,6 +106,10 @@ function pickTransformersForActivePlugins(pluginIds: string[], allowedHeadingLev
       type: 'element'
     }
     transformers.push(HEADING)
+  }
+
+  if (pluginIds.includes('thematicBreak')) {
+    transformers.push(THEMATIC_BREAK)
   }
 
   if (pluginIds.includes('quote')) {

--- a/src/plugins/thematic-break/index.ts
+++ b/src/plugins/thematic-break/index.ts
@@ -2,7 +2,7 @@ import { realmPlugin } from '../../RealmWithPlugins'
 import { HorizontalRuleNode, INSERT_HORIZONTAL_RULE_COMMAND } from '@lexical/react/LexicalHorizontalRuleNode.js'
 import { HorizontalRulePlugin } from '@lexical/react/LexicalHorizontalRulePlugin.js'
 import { Action, withLatestFrom } from '@mdxeditor/gurx'
-import { activeEditor$, addComposerChild$, addExportVisitor$, addImportVisitor$, addLexicalNode$ } from '../core'
+import { activeEditor$, addActivePlugin$, addComposerChild$, addExportVisitor$, addImportVisitor$, addLexicalNode$ } from '../core'
 import { LexicalThematicBreakVisitor } from './LexicalThematicBreakVisitor'
 import { MdastThematicBreakVisitor } from './MdastThematicBreakVisitor'
 
@@ -23,6 +23,7 @@ export const insertThematicBreak$ = Action((r) => {
 export const thematicBreakPlugin = realmPlugin({
   init(realm) {
     realm.pubIn({
+      [addActivePlugin$]: 'thematicBreak',
       [addImportVisitor$]: MdastThematicBreakVisitor,
       [addLexicalNode$]: HorizontalRuleNode,
       [addExportVisitor$]: LexicalThematicBreakVisitor,


### PR DESCRIPTION
This PR adds support for typing `---` or `***` or `___` to insert a thematic break node (Horizontal rule).

Sadly, as in of Lexical basic MarkdownShortcuts plugin, one needs to press space immediately after the trigger characters, and it does not work if one presses enter immediately. 

It would be nice to address the issue in a separate MR