### PR TITLE
feat: add prop to control toolbar positioning above or below editor

### DIFF
--- a/docs/customizing-toolbar.md
+++ b/docs/customizing-toolbar.md
@@ -6,7 +6,7 @@ position: 0.2
 
 # Toolbar
 
-MDXEditor includes a toolbar plugin and a set of toolbar components that you can arrange up to your preferences and the features you have enabled. Most toolbar components need their respective plugins to be enabled in order to work correctly. The next example enables a simple toolbar with undo/redo and bold/italic/underline components in it. Following the same pattern, you can add, rearrange, or add custom toolbar components.
+MDXEditor includes a toolbar plugin and a set of toolbar components that you can arrange based on your preferences and the features you have enabled. Most toolbar components need their respective plugins to be enabled in order to work correctly. The next example enables a simple toolbar with undo/redo and bold/italic/underline components in it. Following the same pattern, you can add, rearrange, or add custom toolbar components.
 
 Note: Most of the components do not accept any properties, but some read the configuration parameters of their respective plugins. A notable exception is the `DiffSourceToggleWrapper` which requires its children to be the toolbar contents.
 
@@ -23,7 +23,6 @@ function App() {
           toolbarClassName: 'my-classname',
           toolbarContents: () => (
             <>
-              {' '}
               <UndoRedo />
               <BoldItalicUnderlineToggles />
             </>

--- a/src/MDXEditor.tsx
+++ b/src/MDXEditor.tsx
@@ -16,6 +16,7 @@ import {
   rootEditor$,
   setMarkdown$,
   topAreaChildren$,
+  bottomAreaChildren$,
   useTranslation,
   viewMode$,
   contentEditableRef$
@@ -51,14 +52,16 @@ const RichTextEditor: React.FC = () => {
     setContentEditableRef({ current: _contentEditableRef })
   }
 
-  const [contentEditableClassName, spellCheck, composerChildren, topAreaChildren, editorWrappers, placeholder] = useCellValues(
-    contentEditableClassName$,
-    spellCheck$,
-    composerChildren$,
-    topAreaChildren$,
-    editorWrappers$,
-    placeholder$
-  )
+  const [contentEditableClassName, spellCheck, composerChildren, topAreaChildren, editorWrappers, placeholder, bottomAreaChildren] =
+    useCellValues(
+      contentEditableClassName$,
+      spellCheck$,
+      composerChildren$,
+      topAreaChildren$,
+      editorWrappers$,
+      placeholder$,
+      bottomAreaChildren$
+    )
   return (
     <>
       {topAreaChildren.map((Child, index) => (
@@ -86,6 +89,9 @@ const RichTextEditor: React.FC = () => {
         </div>
       </RenderRecursiveWrappers>
       {composerChildren.map((Child, index) => (
+        <Child key={index} />
+      ))}
+      {bottomAreaChildren.map((Child, index) => (
         <Child key={index} />
       ))}
     </>

--- a/src/plugins/core/index.ts
+++ b/src/plugins/core/index.ts
@@ -697,6 +697,15 @@ export const topAreaChildren$ = Cell<React.ComponentType[]>([])
 export const addTopAreaChild$ = Appender(topAreaChildren$)
 
 /** @internal */
+export const bottomAreaChildren$ = Cell<React.ComponentType[]>([])
+
+/**
+ * Lets you add React components below the editor.
+ * @group Core
+ */
+export const addBottomAreaChild$ = Appender(bottomAreaChildren$)
+
+/** @internal */
 export const editorWrappers$ = Cell<React.ComponentType<{ children: React.ReactNode }>[]>([])
 
 /**

--- a/src/plugins/toolbar/index.tsx
+++ b/src/plugins/toolbar/index.tsx
@@ -1,7 +1,7 @@
 import { realmPlugin } from '../../RealmWithPlugins'
 import { Cell, useCellValues } from '@mdxeditor/gurx'
 import React from 'react'
-import { addTopAreaChild$, readOnly$ } from '../core'
+import { addTopAreaChild$, addBottomAreaChild$, readOnly$ } from '../core'
 import { Root } from './primitives/toolbar'
 
 /**
@@ -19,12 +19,26 @@ const DEFAULT_TOOLBAR_CONTENTS = () => {
  * A plugin that adds a toolbar to the editor.
  * @group Toolbar
  */
-export const toolbarPlugin = realmPlugin<{ toolbarContents: () => React.ReactNode; toolbarClassName?: string }>({
+export const toolbarPlugin = realmPlugin<{
+  /**
+   * Contents of the toolbar
+   */
+  toolbarContents: () => React.ReactNode
+  /**
+   * The class name to apply to the toolbar element
+   */
+  toolbarClassName?: string
+  /**
+   * Controls the position of the toolbar (top by default)
+   */
+  toolbarPosition?: 'top' | 'bottom'
+}>({
   init(realm, params) {
+    const toolbarPositionSymbol = params?.toolbarPosition === 'bottom' ? addBottomAreaChild$ : addTopAreaChild$
     realm.pubIn({
       [toolbarContents$]: params?.toolbarContents ?? DEFAULT_TOOLBAR_CONTENTS,
       [toolbarClassName$]: params?.toolbarClassName ?? '',
-      [addTopAreaChild$]: () => {
+      [toolbarPositionSymbol]: () => {
         const [toolbarContents, readOnly, toolbarClassName] = useCellValues(toolbarContents$, readOnly$, toolbarClassName$)
         return (
           <Root className={toolbarClassName} readOnly={readOnly}>


### PR DESCRIPTION
This change allows the toolbar to render under the editor via a new prop on the `toolbarPlugin` function.

For my use-case, the designs places the toolbar under the editor and while it is possible to visually change the ordering using `toolbarClassName`, it does not affect the order of DOM nodes (and therefore keyboard behaviour).