### PR TITLE
feat: add option to escape unknown text directives

### DIFF
--- a/src/examples/directives.tsx
+++ b/src/examples/directives.tsx
@@ -118,6 +118,24 @@ export const CatchAll: React.FC = () => {
   return <MDXEditor markdown={genericMarkdown} plugins={[directivesPlugin({ directiveDescriptors: [GenericDirectiveDescriptor] })]} />
 }
 
+export const EscapeUnknownTextDirectivesAll: React.FC = () => {
+  const [mdSource, setMdSource] = React.useState('');
+  return (
+    <div>
+      <MDXEditor 
+        markdown={`She:he arrived at the party wearing her:his favorite dress:suit.`} 
+        plugins={[directivesPlugin({ escapeUnknownTextDirectives: true, directiveDescriptors: [] })]}
+        onChange={(md) => setMdSource(md)}
+      />
+      <pre>
+        <code>
+          {mdSource}
+        </code>
+      </pre>
+    </div>
+  )
+}
+
 export const Admonitions: React.FC = () => {
   return (
     <MDXEditor

--- a/src/examples/directives.tsx
+++ b/src/examples/directives.tsx
@@ -119,18 +119,16 @@ export const CatchAll: React.FC = () => {
 }
 
 export const EscapeUnknownTextDirectives: React.FC = () => {
-  const [mdSource, setMdSource] = React.useState('');
+  const [mdSource, setMdSource] = React.useState('')
   return (
     <div>
-      <MDXEditor 
-        markdown={`She:he arrived at the party wearing her:his favorite dress:suit.`} 
+      <MDXEditor
+        markdown={`She:he arrived at the party wearing her:his favorite dress:suit.`}
         plugins={[directivesPlugin({ escapeUnknownTextDirectives: true, directiveDescriptors: [] })]}
-        onChange={(md) => setMdSource(md)}
+        onChange={setMdSource}
       />
       <pre>
-        <code>
-          {mdSource}
-        </code>
+        <code>{mdSource}</code>
       </pre>
     </div>
   )

--- a/src/examples/directives.tsx
+++ b/src/examples/directives.tsx
@@ -118,7 +118,7 @@ export const CatchAll: React.FC = () => {
   return <MDXEditor markdown={genericMarkdown} plugins={[directivesPlugin({ directiveDescriptors: [GenericDirectiveDescriptor] })]} />
 }
 
-export const EscapeUnknownTextDirectivesAll: React.FC = () => {
+export const EscapeUnknownTextDirectives: React.FC = () => {
   const [mdSource, setMdSource] = React.useState('');
   return (
     <div>

--- a/src/plugins/directives/MdastDirectiveVisitor.ts
+++ b/src/plugins/directives/MdastDirectiveVisitor.ts
@@ -14,26 +14,28 @@ export function isMdastDirectivesNode(node: Mdast.Nodes): node is Directives {
   return DIRECTIVE_TYPES.includes(node.type)
 }
 
-export const MdastDirectiveVisitor: (escapeUnknownTextDirectives?: boolean) => MdastImportVisitor<Directives> = (escapeUnknownTextDirectives) => ({
+export const MdastDirectiveVisitor: (escapeUnknownTextDirectives?: boolean) => MdastImportVisitor<Directives> = (
+  escapeUnknownTextDirectives
+) => ({
   testNode: (node, { directiveDescriptors }) => {
     if (isMdastDirectivesNode(node)) {
       const descriptor = directiveDescriptors.find((descriptor) => descriptor.testNode(node))
       if (escapeUnknownTextDirectives && !descriptor && node.type === 'textDirective') {
-        return true;
+        return true
       }
       return descriptor !== undefined
     }
     return false
   },
   visitNode({ lexicalParent, mdastNode, descriptors }) {
-    const isKnown = !escapeUnknownTextDirectives || descriptors.directiveDescriptors.some(d => d.testNode(mdastNode));
+    const isKnown = !escapeUnknownTextDirectives || descriptors.directiveDescriptors.some((d) => d.testNode(mdastNode))
     if (isKnown) {
-      (lexicalParent as ElementNode).append($createDirectiveNode(mdastNode));
+      ;(lexicalParent as ElementNode).append($createDirectiveNode(mdastNode))
     } else {
       /**
        * it is a text-directive and can only occur when `escapeUnknownTextDirectives` is true.
        */
-      (lexicalParent as ElementNode).append($createTextNode(`:${mdastNode.name}`));
+      ;(lexicalParent as ElementNode).append($createTextNode(`:${mdastNode.name}`))
     }
   }
-});
+})

--- a/src/plugins/directives/index.ts
+++ b/src/plugins/directives/index.ts
@@ -102,12 +102,12 @@ export const directivesPlugin = realmPlugin<{
   /**
    * Use this to register your custom directive editors. You can also use the built-in {@link GenericDirectiveEditor}.
    */
-  directiveDescriptors: DirectiveDescriptor<any>[],
+  directiveDescriptors: DirectiveDescriptor<any>[]
   /**
    * Set this option to display unknown text-directives as normal text nodes.
    * This is handy when colons are used to separate words, e.g. in german "Schüler:in"
    */
-  escapeUnknownTextDirectives?: boolean;
+  escapeUnknownTextDirectives?: boolean
 }>({
   update: (realm, params) => {
     // eslint-disable-next-line @typescript-eslint/no-unsafe-argument

--- a/src/plugins/directives/index.ts
+++ b/src/plugins/directives/index.ts
@@ -102,7 +102,12 @@ export const directivesPlugin = realmPlugin<{
   /**
    * Use this to register your custom directive editors. You can also use the built-in {@link GenericDirectiveEditor}.
    */
-  directiveDescriptors: DirectiveDescriptor<any>[]
+  directiveDescriptors: DirectiveDescriptor<any>[],
+  /**
+   * Set this option to display unknown text-directives as normal text nodes.
+   * This is handy when colons are used to separate words, e.g. in german "Schüler:in"
+   */
+  escapeUnknownTextDirectives?: boolean;
 }>({
   update: (realm, params) => {
     // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
@@ -115,7 +120,7 @@ export const directivesPlugin = realmPlugin<{
       // import
       [addMdastExtension$]: directiveFromMarkdown(),
       [addSyntaxExtension$]: directive(),
-      [addImportVisitor$]: MdastDirectiveVisitor,
+      [addImportVisitor$]: MdastDirectiveVisitor(params?.escapeUnknownTextDirectives),
       // export
       [addLexicalNode$]: DirectiveNode,
       [addExportVisitor$]: DirectiveVisitor,


### PR DESCRIPTION
# Add `escapeUnknownTextDirectives` option
When editing german text, a colon is often used to separate words. Since the separated word is treated as a directive, the mdx editor will either show an error message or the `GenericDirectiveDescriptor` is used to catch all unknown occurences, what leads to an unwanted behavior.

This PR allows to configure the MdastDirectiveVisitor to accept the option `escapeUnknownTextDirectives`. In this case unknwon `textDirectives` are rendered as text instead of mdastDirectives.

## Example

```md
Alle Schüler:innen der Schule.
```

would be rendered as
```
Alle Schüler\:innen der Schule.
```
 