### PR TITLE
fix: link & image dialog re-renders issue that causes editor laggy

### DIFF
--- a/src/plugins/image/ImageDialog.tsx
+++ b/src/plugins/image/ImageDialog.tsx
@@ -31,9 +31,11 @@ export const ImageDialog: React.FC = () => {
     values: state.type === 'editing' ? (state.initialValues as any) : {}
   })
 
+  if (state.type === 'inactive') return null
+
   return (
     <Dialog.Root
-      open={state.type !== 'inactive'}
+      open={true}
       onOpenChange={(open) => {
         if (!open) {
           closeImageDialog()

--- a/src/plugins/link-dialog/LinkDialog.tsx
+++ b/src/plugins/link-dialog/LinkDialog.tsx
@@ -144,20 +144,22 @@ export const LinkDialog: React.FC = () => {
 
   const t = useTranslation()
 
+  if (linkDialogState.type === 'inactive') return null
+
   const theRect = linkDialogState.rectangle
 
   const urlIsExternal = linkDialogState.type === 'preview' && linkDialogState.url.startsWith('http')
 
   return (
-    <Popover.Root open={linkDialogState.type !== 'inactive'}>
+    <Popover.Root open={true}>
       <Popover.Anchor
         data-visible={linkDialogState.type === 'edit'}
         className={styles.linkDialogAnchor}
         style={{
-          top: `${theRect?.top ?? 0}px`,
-          left: `${theRect?.left ?? 0}px`,
-          width: `${theRect?.width ?? 0}px`,
-          height: `${theRect?.height ?? 0}px`
+          top: `${theRect.top}px`,
+          left: `${theRect.left}px`,
+          width: `${theRect.width}px`,
+          height: `${theRect.height}px`
         }}
       />
 


### PR DESCRIPTION
## Summary
After emitting a lot of keystrokes the editor (that uses link & image dialog) become so laggy because both dialogs re-rendered in every keystores.

this issue can easily reproduced on the live demo

### Screen Recording

https://github.com/user-attachments/assets/109429fe-aba4-436f-a10f-8442e7c7f002

### Solution
return null instead of component if the current state not relevant to each dialogs
