### PR TITLE
Add ability to modify the image editor toolbar

### DIFF
--- a/src/plugins/image/EditImageToolbar.tsx
+++ b/src/plugins/image/EditImageToolbar.tsx
@@ -1,0 +1,62 @@
+import { useLexicalComposerContext } from '@lexical/react/LexicalComposerContext'
+import { useCellValues, usePublisher } from '@mdxeditor/gurx'
+import classNames from 'classnames'
+import { $getNodeByKey } from 'lexical'
+import React from 'react'
+import { disableImageSettingsButton$, openEditImageDialog$ } from '.'
+import styles from '../../styles/ui.module.css'
+import { iconComponentFor$, readOnly$, useTranslation } from '../core'
+
+export interface EditImageToolbarProps {
+  nodeKey: string
+  imageSource: string
+  initialImagePath: string | null
+  title: string
+  alt: string
+}
+
+export function EditImageToolbar({ nodeKey, imageSource, initialImagePath, title, alt }: EditImageToolbarProps): JSX.Element {
+  const [disableImageSettingsButton, iconComponentFor, readOnly] = useCellValues(disableImageSettingsButton$, iconComponentFor$, readOnly$)
+  const [editor] = useLexicalComposerContext()
+  const openEditImageDialog = usePublisher(openEditImageDialog$)
+  const t = useTranslation()
+
+  return (
+    <div className={styles.editImageToolbar}>
+      <button
+        className={styles.iconButton}
+        type="button"
+        title={t('imageEditor.deleteImage', 'Delete image')}
+        disabled={readOnly}
+        onClick={(e) => {
+          e.preventDefault()
+          editor.update(() => {
+            $getNodeByKey(nodeKey)?.remove()
+          })
+        }}
+      >
+        {iconComponentFor('delete_small')}
+      </button>
+      {!disableImageSettingsButton && (
+        <button
+          type="button"
+          className={classNames(styles.iconButton, styles.editImageButton)}
+          title={t('imageEditor.editImage', 'Edit image')}
+          disabled={readOnly}
+          onClick={() => {
+            openEditImageDialog({
+              nodeKey: nodeKey,
+              initialValues: {
+                src: !initialImagePath ? imageSource : initialImagePath,
+                title,
+                altText: alt
+              }
+            })
+          }}
+        >
+          {iconComponentFor('settings')}
+        </button>
+      )}
+    </div>
+  )
+}

--- a/src/plugins/image/index.ts
+++ b/src/plugins/image/index.ts
@@ -31,6 +31,7 @@ import {
   addLexicalNode$,
   createActiveEditorSubscription$
 } from '../core'
+import { EditImageToolbar, EditImageToolbarProps } from './EditImageToolbar'
 import { ImageDialog } from './ImageDialog'
 import { $createImageNode, $isImageNode, CreateImageNodeParameters, ImageNode } from './ImageNode'
 import { LexicalImageVisitor } from './LexicalImageVisitor'
@@ -323,6 +324,12 @@ export const disableImageSettingsButton$ = Cell<boolean>(false)
 export const saveImage$ = Signal<SaveImageParameters>()
 
 /**
+ * Holds the custom EditImageToolbar component.
+ * @group Image
+ */
+export const editImageToolbarComponent$ = Cell<React.FC<EditImageToolbarProps>>(EditImageToolbar)
+
+/**
  * A plugin that adds support for images.
  * @group Image
  */
@@ -333,6 +340,7 @@ export const imagePlugin = realmPlugin<{
   disableImageSettingsButton?: boolean
   imagePreviewHandler?: ImagePreviewHandler
   ImageDialog?: (() => JSX.Element) | React.FC
+  EditImageToolbar?: (() => JSX.Element) | React.FC
 }>({
   init(realm, params) {
     realm.pubIn({
@@ -344,7 +352,8 @@ export const imagePlugin = realmPlugin<{
       [imageAutocompleteSuggestions$]: params?.imageAutocompleteSuggestions ?? [],
       [disableImageResize$]: Boolean(params?.disableImageResize),
       [disableImageSettingsButton$]: Boolean(params?.disableImageSettingsButton),
-      [imagePreviewHandler$]: params?.imagePreviewHandler ?? null
+      [imagePreviewHandler$]: params?.imagePreviewHandler ?? null,
+      [editImageToolbarComponent$]: params?.EditImageToolbar ?? EditImageToolbar
     })
   },
 
@@ -353,7 +362,8 @@ export const imagePlugin = realmPlugin<{
       [imageUploadHandler$]: params?.imageUploadHandler ?? null,
       [imageAutocompleteSuggestions$]: params?.imageAutocompleteSuggestions ?? [],
       [disableImageResize$]: Boolean(params?.disableImageResize),
-      [imagePreviewHandler$]: params?.imagePreviewHandler ?? null
+      [imagePreviewHandler$]: params?.imagePreviewHandler ?? null,
+      [editImageToolbarComponent$]: params?.EditImageToolbar ?? EditImageToolbar
     })
   }
 })


### PR DESCRIPTION
While trying to integrate MDXEditor into my project i ran across an issue where all images had the edit image toolbar which was not astetically alligned with the styling of my website.

The goal of this pr is to allow to customize the toolbar with my own component so i can have a more coherent look to my website.

Thanks!
