### PR TITLE
Add overlayContainer prop so overlay location can be controlled.

### DIFF
--- a/src/MDXEditor.tsx
+++ b/src/MDXEditor.tsx
@@ -171,7 +171,8 @@ const RenderRecursiveWrappers: React.FC<{
 const EditorRootElement: React.FC<{
   children: React.ReactNode
   className?: string
-}> = ({ children, className }) => {
+  overlayContainer?: HTMLElement | null
+}> = ({ children, className, overlayContainer }) => {
   const editorRootElementRef = React.useRef<HTMLDivElement | null>(null)
   const setEditorRootElementRef = usePublisher(editorRootElementRef$)
 
@@ -183,13 +184,14 @@ const EditorRootElement: React.FC<{
       styles.popupContainer,
       ...(className ?? '').trim().split(' ').filter(Boolean)
     )
-    document.body.appendChild(popupContainer)
+    const container = overlayContainer ?? document.body
+    container.appendChild(popupContainer)
     editorRootElementRef.current = popupContainer
     setEditorRootElementRef(editorRootElementRef)
     return () => {
       popupContainer.remove()
     }
-  }, [className, editorRootElementRef, setEditorRootElementRef])
+  }, [className, editorRootElementRef, overlayContainer, setEditorRootElementRef])
   return <div className={classNames('mdxeditor', styles.editorRoot, styles.editorWrapper, className)}>{children}</div>
 }
 
@@ -310,6 +312,12 @@ export interface MDXEditorProps {
    * A custom lexical theme to use for the editor.
    */
   lexicalTheme?: EditorThemeClasses
+
+  /**
+   * Optional container element to use for rendering editor popups.
+   * Defaults to document.body.
+   */
+  overlayContainer?: HTMLElement | null
 }
 
 /**
@@ -340,7 +348,7 @@ export const MDXEditor = React.forwardRef<MDXEditorMethods, MDXEditorProps>((pro
         ...(props.plugins ?? [])
       ]}
     >
-      <EditorRootElement className={props.className}>
+      <EditorRootElement className={props.className} overlayContainer={props.overlayContainer}>
         <LexicalProvider>
           <RichTextEditor />
         </LexicalProvider>

--- a/src/examples/within-dialog.tsx
+++ b/src/examples/within-dialog.tsx
@@ -1,0 +1,44 @@
+import React, { useRef, useState, useCallback } from 'react'
+import { BlockTypeSelect, BoldItalicUnderlineToggles, CreateLink, linkDialogPlugin, MDXEditor } from '../'
+import { headingsPlugin, toolbarPlugin } from '../'
+
+export function WithinDialog() {
+  const dialogRef = useRef<HTMLDialogElement>(null)
+  const [overlayContainer, setOverlayContainer] = useState<HTMLDialogElement | null>(null)
+  const showDialog = useCallback(() => {
+    dialogRef.current?.showModal()
+    setOverlayContainer(dialogRef.current ?? null)
+  }, [dialogRef])
+
+  const closeDialog = useCallback(() => {
+    dialogRef.current?.close()
+  }, [dialogRef])
+
+  return (
+    <>
+      <button onClick={showDialog}>Show dialog</button>
+      <dialog ref={dialogRef}>
+        <button onClick={closeDialog}>Close dialog</button>
+        {dialogRef.current && (
+          <MDXEditor
+            overlayContainer={overlayContainer}
+            markdown="# Hello Dialog"
+            plugins={[
+              headingsPlugin(),
+              linkDialogPlugin(),
+              toolbarPlugin({
+                toolbarContents: () => (
+                  <>
+                    <BoldItalicUnderlineToggles />
+                    <BlockTypeSelect />
+                    <CreateLink />
+                  </>
+                )
+              })
+            ]}
+          />
+        )}
+      </dialog>
+    </>
+  )
+}


### PR DESCRIPTION
fix: Enables setting the overlayContainer on MDXEditor so the implementer can control in which HTML element the popup containers are shown. This enables the usage of MDXEditor within <dialog> HTML elements.

See #752