### PR TITLE
Update toolbar.tsx to remove dublicate tooltips in toggles icons 

### DIFF
--- a/src/plugins/toolbar/primitives/toolbar.tsx
+++ b/src/plugins/toolbar/primitives/toolbar.tsx
@@ -94,7 +94,7 @@ export const ToggleSingleGroupWithItem = React.forwardRef<
       value={on ? 'on' : 'off'}
       ref={forwardedRef}
     >
-      <ToolbarToggleItem title={title} value="on" disabled={disabled}>
+      <ToolbarToggleItem aria-label={title} value="on" disabled={disabled}>
         <TooltipWrap title={title}>{children}</TooltipWrap>
       </ToolbarToggleItem>
     </RadixToolbar.ToggleGroup>


### PR DESCRIPTION
for the bold/italic/underline toggles , both ToolbarToggleItem and TooltipWrap has the title being passed, resulting in both the tooltip from redux + the native html tooltip

Image example:
![image](https://github.com/user-attachments/assets/0652b295-de29-4ba9-b2bc-cc75f7073999)
