### PR TITLE
Fix error in image dialog plugin when changing src of image

### DIFF
--- a/src/plugins/image/index.ts
+++ b/src/plugins/image/index.ts
@@ -77,7 +77,7 @@ export type InsertImageParameters = FileImageParameters | SrcImageParameters
  */
 export interface SaveImageParameters extends BaseImageParameters {
   src?: string
-  file: FileList
+  file?: FileList
 }
 
 /**
@@ -191,7 +191,7 @@ export const imageDialogState$ = Cell<InactiveImageDialogState | NewImageDialogS
                 r.pub(imageDialogState$, { type: 'inactive' })
               }
 
-        if (values.file.length > 0) {
+        if (values.file && values.file.length > 0) {
           imageUploadHandler?.(values.file.item(0)!)
             .then(handler)
             .catch((e: unknown) => {


### PR DESCRIPTION
When changing the source of a current image in the image dialog plugin you get the following error

```
values.file is undefined
TypeError
TypeError: values.file is undefined
```

This is due to the file form field not having a value when editing an existing image node. (_This behavior is likely expected_ ?) 

Therefore checking first if the field is not undefined before checking its length mitigates the error.

The changes in this PR reflect this.