### PR TITLE
image placeholder and image suspense cache

### DIFF
--- a/src/plugins/image/ImageEditor.tsx
+++ b/src/plugins/image/ImageEditor.tsx
@@ -39,13 +39,9 @@ export interface ImageEditorProps {
   rest: (MdxJsxAttribute | MdxJsxExpressionAttribute)[]
 }
 
-interface ImgCache {
-  __cache: Record<string, boolean | Promise<void>>
-  read(src: string): boolean
-}
 // https://css-tricks.com/pre-caching-image-with-react-suspense/
-const imgCache: ImgCache = {
-  __cache: {},
+const imgCache = {
+  __cache: {} as Record<string, boolean | Promise<void>>,
   read(src: string) {
     if (!this.__cache[src]) {
       this.__cache[src] = new Promise<void>((resolve) => {
@@ -82,7 +78,7 @@ function LazyImage({
   width: number | 'inherit'
   height: number | 'inherit'
 }): JSX.Element {
-  imgCache.read(src)
+  void imgCache.read(src)
   return (
     <img
       className={className ?? undefined}

--- a/src/plugins/image/index.ts
+++ b/src/plugins/image/index.ts
@@ -1,3 +1,4 @@
+import { ImagePlaceholder } from '@/plugins/image/ImageEditor'
 import { $wrapNodeInElement, mergeRegister } from '@lexical/utils'
 import { Action, Cell, Signal, map, mapTo, withLatestFrom } from '@mdxeditor/gurx'
 import {
@@ -162,6 +163,12 @@ export const imageUploadHandler$ = Cell<ImageUploadHandler>(null)
  * @group Image
  */
 export const imagePreviewHandler$ = Cell<ImagePreviewHandler>(null)
+
+/**
+ * Holds the image placeholder.
+ * @group Image
+ */
+export const imagePlaceholder$ = Cell<typeof ImagePlaceholder | null>(null)
 
 /**
  * Holds the current state of the image dialog.
@@ -341,6 +348,7 @@ export const imagePlugin = realmPlugin<{
   imagePreviewHandler?: ImagePreviewHandler
   ImageDialog?: (() => JSX.Element) | React.FC
   EditImageToolbar?: (() => JSX.Element) | React.FC
+  imagePlaceholder?: (() => JSX.Element) | null
 }>({
   init(realm, params) {
     realm.pubIn({
@@ -353,7 +361,8 @@ export const imagePlugin = realmPlugin<{
       [disableImageResize$]: Boolean(params?.disableImageResize),
       [disableImageSettingsButton$]: Boolean(params?.disableImageSettingsButton),
       [imagePreviewHandler$]: params?.imagePreviewHandler ?? null,
-      [editImageToolbarComponent$]: params?.EditImageToolbar ?? EditImageToolbar
+      [editImageToolbarComponent$]: params?.EditImageToolbar ?? EditImageToolbar,
+      [imagePlaceholder$]: params?.imagePlaceholder ?? ImagePlaceholder
     })
   },
 
@@ -363,7 +372,8 @@ export const imagePlugin = realmPlugin<{
       [imageAutocompleteSuggestions$]: params?.imageAutocompleteSuggestions ?? [],
       [disableImageResize$]: Boolean(params?.disableImageResize),
       [imagePreviewHandler$]: params?.imagePreviewHandler ?? null,
-      [editImageToolbarComponent$]: params?.EditImageToolbar ?? EditImageToolbar
+      [editImageToolbarComponent$]: params?.EditImageToolbar ?? EditImageToolbar,
+      [imagePlaceholder$]: params?.imagePlaceholder ?? ImagePlaceholder
     })
   }
 })

--- a/src/styles/ui.module.css
+++ b/src/styles/ui.module.css
@@ -1090,6 +1090,14 @@
   cursor: nw-resize;
 }
 
+.imagePlaceholder {
+  border: 2px dashed;
+  padding: 48px;
+  margin: 12px;
+  width: fit-content;
+  height: fit-content;
+}
+
 .placeholder {
   color: var(--baseSolid);
   overflow: hidden;


### PR DESCRIPTION
This PR does two things

- Uses a cache mechanism for the suspended promise for lazy image, this prevents multiple promises for the same image when the component re-renders

- Adds a default image placeholder while image is loading (see attached image),`imagePlaceholder` is also made as an option for the image plugin

<img width="357" alt="screenshot" src="https://github.com/user-attachments/assets/c7ad5898-698f-4166-956c-51a6d17e9636" />
