### PR TITLE
Allow drag and drop image plugin to use type string in dataTransfer item

### DIFF
--- a/src/plugins/image/index.ts
+++ b/src/plugins/image/index.ts
@@ -450,7 +450,16 @@ function onDrop(event: DragEvent, editor: LexicalEditor, imageUploadHandler: Ima
   if (cbPayload.length > 0) {
     if (imageUploadHandler !== null) {
       event.preventDefault()
-      Promise.all(cbPayload.map((image) => imageUploadHandler(image.getAsFile()!)))
+      Promise.all(
+        cbPayload.map((image) => {
+          if (image.kind === 'string') {
+            return new Promise<string>((rs) => {
+              image.getAsString(rs)
+            })
+          }
+          return imageUploadHandler(image.getAsFile()!)
+        })
+      )
         .then((urls) => {
           urls.forEach((url) => {
             editor.dispatchCommand(INSERT_IMAGE_COMMAND, {


### PR DESCRIPTION
### PR Overview

This update allows drag and drop image plugin to use type string in dataTransfer item. Currently just File instance types are supported. This enhancement is specifically for internal (in-browser) image drag-and-drop functionality. By using the `getAsString` method, the URL of the image is directly retrieved, bypassing the imageUploadHandler function by using the url contained in the string dataTransfer item value.

### Use Case

When using a file explorer within the browser, dragging an image from the explorer to the editor does not work in Chrome or Safari. This limitation arises because these browsers do not allow `File` objects to be added to the `dataTransfer` items, preventing access to them in the drop handler.

### Example

Current support allows the use case of dragging from external explorers into the editor. This will create a dataTransfer item of type File. This is not possible from an internal browser drag start location. Though, it is possible to add a dataTransfer File type in FireFox only[1] on dragStart - not Chrome and Safari. The following example, when done on drag start will work across all browsers, given the changes from this PR.

```javascript
dataTransfer.setData("image/jpeg", "/filepath.jpg");
```

When the drop event occurs, the `getAsString` method will retrieve the string `'/filepath.jpg'`, allowing the image to be processed correctly.

### Compatibility

These changes do not affect the existing functionality of dragging external image files into the editor. The original drag-and-drop capabilities remain intact.

### Notes
[1]: 'Bug' for reference is here: [https://stackoverflow.com/questions/24496989/how-to-add-a-file-into-an-already-existing-datatransfer-object-using-javascript](https://stackoverflow.com/questions/24496989/how-to-add-a-file-into-an-already-existing-datatransfer-object-using-javascript) 