### PR TITLE
add back img.onerror in lazy img cache

### DIFF
--- a/src/plugins/image/ImageEditor.tsx
+++ b/src/plugins/image/ImageEditor.tsx
@@ -45,7 +45,7 @@ const imgCache = {
     if (!this.__cache[src]) {
       this.__cache[src] = new Promise<void>((resolve) => {
         const img = new Image()
-        img.onload = () => {
+        img.onerror = img.onload = () => {
           this.__cache[src] = true
           resolve()
         }


### PR DESCRIPTION
# Add back img.onerror in lazy img cache

Without this, error'd/404 images will just continue showing the placeholder when the request is error'd/404

With this change, the image editor button and image delete button will still show 
