### PR TITLE
Img error placeholder shows error

### DIFF
--- a/src/plugins/image/index.ts
+++ b/src/plugins/image/index.ts
@@ -450,7 +450,16 @@ function onDrop(event: DragEvent, editor: LexicalEditor, imageUploadHandler: Ima
   if (cbPayload.length > 0) {
     if (imageUploadHandler !== null) {
       event.preventDefault()
-      Promise.all(cbPayload.map((image) => imageUploadHandler(image.getAsFile()!)))
+      Promise.all(
+        cbPayload.map((image) => {
+          if (image.kind === 'string') {
+            return new Promise<string>((rs) => {
+              image.getAsString(rs)
+            })
+          }
+          return imageUploadHandler(image.getAsFile()!)
+        })
+      )
         .then((urls) => {
           urls.forEach((url) => {
             editor.dispatchCommand(INSERT_IMAGE_COMMAND, {


### PR DESCRIPTION
when an image does not load, the following placeholder will show indicating an issue loading.

<img width="249" alt="Screenshot 2025-05-13 at 7 54 25 PM" src="https://github.com/user-attachments/assets/3895be70-78ce-4294-b045-d9987d6c14f3" />

This also remedies (#770 ) the lack of img.onerror in the lazy error image handler. the problem was just the placeholder showing upon error, making it difficult to delete or edit the image
