### PR TITLE
Makes using an external realm context alternative possible

### DIFF
--- a/src/MDXEditor.tsx
+++ b/src/MDXEditor.tsx
@@ -358,3 +358,23 @@ export const MDXEditor = React.forwardRef<MDXEditorMethods, MDXEditorProps>((pro
     </RealmWithPlugins>
   )
 })
+
+/**
+ * The MDXEditor React component without the realm and plugins.
+ * This is useful if you want to expand the reach of the Realm context by including it's
+ * instantiation in your own code. Therefore by using this component, you must be sure to then
+ * provide the `RealmWithPlugins` component at a higher level in your component tree.
+ * @group MDXEditor
+ */
+export const MDXEditorWithoutRealmAndPlugins = React.forwardRef<MDXEditorMethods, MDXEditorProps>((props, ref) => {
+  return (
+    <>
+      <EditorRootElement className={props.className} overlayContainer={props.overlayContainer}>
+        <LexicalProvider>
+          <RichTextEditor />
+        </LexicalProvider>
+      </EditorRootElement>
+      <Methods mdxRef={ref} />
+    </>
+  )
+})

--- a/src/MDXEditor.tsx
+++ b/src/MDXEditor.tsx
@@ -361,9 +361,24 @@ export const MDXEditor = React.forwardRef<MDXEditorMethods, MDXEditorProps>((pro
 
 /**
  * The MDXEditor React component without the realm and plugins.
- * This is useful if you want to expand the reach of the Realm context by including it's
+ * This is useful if you want to expand the reach of the Realm context by including its
  * instantiation in your own code. Therefore by using this component, you must be sure to then
  * provide the `RealmWithPlugins` component at a higher level in your component tree.
+ *
+ * @example
+ * ```tsx
+ *
+ * import { RealmWithPlugins, MDXEditorWithoutRealmAndPlugins } from 'mdxeditor'
+ *
+ * function MyEditor() {
+ *   return (
+ *     <RealmWithPlugins plugins={[Plugin1, Plugin2, Plugin3]} realm={myRealm}>
+ *       <MDXEditorWithoutRealmAndPlugins markdown="Hello, world!" />
+ *     </RealmWithPlugins>
+ *   )
+ * }
+ * ```
+ *
  * @group MDXEditor
  */
 export const MDXEditorWithoutRealmAndPlugins = React.forwardRef<MDXEditorMethods, MDXEditorProps>((props, ref) => {

--- a/src/RealmWithPlugins.tsx
+++ b/src/RealmWithPlugins.tsx
@@ -41,7 +41,14 @@ export function realmPlugin<Params>(plugin: {
   }
 }
 
-/** @internal */
+/**
+ * Provides a Realm instance and connects plugins to use it as well as run init, post init and
+ * update hooks of plugins
+ * @param children - The children to render within the realm context.
+ * @param plugins - The plugins to use.
+ * @returns A React component that provides the realm context.
+ * @group Core
+ */
 export function RealmWithPlugins({ children, plugins }: { children: React.ReactNode; plugins: RealmPlugin[] }) {
   const theRealm = React.useMemo(() => {
     return tap(new Realm(), (r) => {

--- a/src/RealmWithPlugins.tsx
+++ b/src/RealmWithPlugins.tsx
@@ -46,12 +46,13 @@ export function realmPlugin<Params>(plugin: {
  * update hooks of plugins
  * @param children - The children to render within the realm context.
  * @param plugins - The plugins to use.
+ * @param realm - An optional Realm instance to use. If not provided, a new Realm instance will be created.
  * @returns A React component that provides the realm context.
  * @group Core
  */
-export function RealmWithPlugins({ children, plugins }: { children: React.ReactNode; plugins: RealmPlugin[] }) {
+export function RealmWithPlugins({ children, plugins, realm }: { children: React.ReactNode; plugins: RealmPlugin[]; realm?: Realm }) {
   const theRealm = React.useMemo(() => {
-    return tap(new Realm(), (r) => {
+    return tap(realm ?? new Realm(), (r) => {
       for (const plugin of plugins) {
         plugin.init?.(r)
       }


### PR DESCRIPTION
creates a new export `MDXEditorWithoutRealmAndPlugins` as well as make `RealmWithPlugins` an export, so realm context can optionally be manually provided by the mdxeditor consumer. The aim is to give the consumer more control over the plugins and the context if needed. An optional `realm` argument has also been given to `RealmWithPlugins` so you may pass your own realm