### PR TITLE
skip fn in visitor actions in import and export markdown visit functions

### DIFF
--- a/src/exportMarkdownFromLexical.ts
+++ b/src/exportMarkdownFromLexical.ts
@@ -2,10 +2,10 @@ import { $isElementNode, ElementNode as LexicalElementNode, LexicalNode, RootNod
 import * as Mdast from 'mdast'
 import type { MdxjsEsm } from 'mdast-util-mdx'
 import { Options as ToMarkdownOptions, toMarkdown } from 'mdast-util-to-markdown'
-import { ImportStatement } from './importMarkdownToLexical'
-import { isMdastHTMLNode } from './plugins/core/MdastHTMLNode'
 import type { JsxComponentDescriptor } from './plugins/jsx'
+import { isMdastHTMLNode } from './plugins/core/MdastHTMLNode'
 import { mergeStyleAttributes } from './utils/mergeStyleAttributes'
+import { ImportStatement } from './importMarkdownToLexical'
 
 export type { Options as ToMarkdownOptions } from 'mdast-util-to-markdown'
 

--- a/src/exportMarkdownFromLexical.ts
+++ b/src/exportMarkdownFromLexical.ts
@@ -65,9 +65,9 @@ export interface LexicalExportVisitor<LN extends LexicalNode, UN extends Mdast.N
        */
       visit(node: LexicalNode, parent: Mdast.Parent): void
       /**
-       * Skip the visitor to move along the visitors chain for potential processing from a different visitor with a lower priority
+       * Go to next visitor in the visitors chain for potential processing from a different visitor with a lower priority
        */
-      skip(): void
+      nextVisitor(): void
     }
   }): void
 
@@ -167,9 +167,9 @@ export function exportLexicalTreeToMdast({
     })
   }
 
-  function visit(lexicalNode: LexicalNode, mdastParent: Mdast.Parent | null, skipVisitor?: LexicalVisitor) {
+  function visit(lexicalNode: LexicalNode, mdastParent: Mdast.Parent | null, visitorToSkip?: LexicalVisitor) {
     const visitor = visitors.find((visitor) => {
-      if (visitor === skipVisitor) {
+      if (visitor === visitorToSkip) {
         return false
       }
       return visitor.testLexicalNode?.(lexicalNode)
@@ -198,7 +198,7 @@ export function exportLexicalTreeToMdast({
         visitChildren,
         visit,
         registerReferredComponent,
-        skip() {
+        nextVisitor() {
           visit(lexicalNode, mdastParent, visitor)
           return
         }

--- a/src/exportMarkdownFromLexical.ts
+++ b/src/exportMarkdownFromLexical.ts
@@ -2,10 +2,10 @@ import { $isElementNode, ElementNode as LexicalElementNode, LexicalNode, RootNod
 import * as Mdast from 'mdast'
 import type { MdxjsEsm } from 'mdast-util-mdx'
 import { Options as ToMarkdownOptions, toMarkdown } from 'mdast-util-to-markdown'
-import type { JsxComponentDescriptor } from './plugins/jsx'
-import { isMdastHTMLNode } from './plugins/core/MdastHTMLNode'
-import { mergeStyleAttributes } from './utils/mergeStyleAttributes'
 import { ImportStatement } from './importMarkdownToLexical'
+import { isMdastHTMLNode } from './plugins/core/MdastHTMLNode'
+import type { JsxComponentDescriptor } from './plugins/jsx'
+import { mergeStyleAttributes } from './utils/mergeStyleAttributes'
 
 export type { Options as ToMarkdownOptions } from 'mdast-util-to-markdown'
 
@@ -167,9 +167,9 @@ export function exportLexicalTreeToMdast({
     })
   }
 
-  function visit(lexicalNode: LexicalNode, mdastParent: Mdast.Parent | null, visitorToSkip?: LexicalVisitor) {
-    const visitor = visitors.find((visitor) => {
-      if (visitor === visitorToSkip) {
+  function visit(lexicalNode: LexicalNode, mdastParent: Mdast.Parent | null, skipVisitors = new Set<number>()) {
+    const visitor = visitors.find((visitor, index) => {
+      if (skipVisitors.has(index)) {
         return false
       }
       return visitor.testLexicalNode?.(lexicalNode)
@@ -199,7 +199,7 @@ export function exportLexicalTreeToMdast({
         visit,
         registerReferredComponent,
         nextVisitor() {
-          visit(lexicalNode, mdastParent, visitor)
+          visit(lexicalNode, mdastParent, skipVisitors.add(visitors.indexOf(visitor)))
           return
         }
       }

--- a/src/exportMarkdownFromLexical.ts
+++ b/src/exportMarkdownFromLexical.ts
@@ -167,9 +167,9 @@ export function exportLexicalTreeToMdast({
     })
   }
 
-  function visit(lexicalNode: LexicalNode, mdastParent: Mdast.Parent | null, skipVisitors = new Set<number>()) {
+  function visit(lexicalNode: LexicalNode, mdastParent: Mdast.Parent | null, skipVisitors: Set<number> | null = null) {
     const visitor = visitors.find((visitor, index) => {
-      if (skipVisitors.has(index)) {
+      if (skipVisitors?.has(index)) {
         return false
       }
       return visitor.testLexicalNode?.(lexicalNode)
@@ -199,7 +199,7 @@ export function exportLexicalTreeToMdast({
         visit,
         registerReferredComponent,
         nextVisitor() {
-          visit(lexicalNode, mdastParent, skipVisitors.add(visitors.indexOf(visitor)))
+          visit(lexicalNode, mdastParent, (skipVisitors ?? new Set()).add(visitors.indexOf(visitor)))
           return
         }
       }

--- a/src/exportMarkdownFromLexical.ts
+++ b/src/exportMarkdownFromLexical.ts
@@ -167,9 +167,9 @@ export function exportLexicalTreeToMdast({
     })
   }
 
-  function visit(lexicalNode: LexicalNode, mdastParent: Mdast.Parent | null, skipVisitors: Set<number> | null = null) {
+  function visit(lexicalNode: LexicalNode, mdastParent: Mdast.Parent | null, usedVisitors: Set<number> | null = null) {
     const visitor = visitors.find((visitor, index) => {
-      if (skipVisitors?.has(index)) {
+      if (usedVisitors?.has(index)) {
         return false
       }
       return visitor.testLexicalNode?.(lexicalNode)
@@ -199,7 +199,7 @@ export function exportLexicalTreeToMdast({
         visit,
         registerReferredComponent,
         nextVisitor() {
-          visit(lexicalNode, mdastParent, (skipVisitors ?? new Set()).add(visitors.indexOf(visitor)))
+          visit(lexicalNode, mdastParent, (usedVisitors ?? new Set()).add(visitors.indexOf(visitor)))
           return
         }
       }

--- a/src/importMarkdownToLexical.ts
+++ b/src/importMarkdownToLexical.ts
@@ -262,10 +262,10 @@ export function importMdastTreeToLexical({ root, mdastRoot, visitors, ...descrip
     mdastNode: Mdast.RootContent | Mdast.Root,
     lexicalParent: LexicalNode,
     mdastParent: Mdast.Parent | null,
-    skipVisitors = new Set<number>()
+    skipVisitors: Set<number> | null = null
   ) {
     const visitor = visitors.find((visitor, index) => {
-      if (skipVisitors.has(index)) {
+      if (skipVisitors?.has(index)) {
         return false
       }
       if (typeof visitor.testNode === 'string') {
@@ -296,7 +296,7 @@ export function importMdastTreeToLexical({ root, mdastRoot, visitors, ...descrip
       actions: {
         visitChildren,
         nextVisitor() {
-          visit(mdastNode, lexicalParent, mdastParent, skipVisitors.add(visitors.indexOf(visitor)))
+          visit(mdastNode, lexicalParent, mdastParent, (skipVisitors ?? new Set()).add(visitors.indexOf(visitor)))
         },
         addAndStepInto(lexicalNode) {
           ;(lexicalParent as ElementNode).append(lexicalNode)

--- a/src/importMarkdownToLexical.ts
+++ b/src/importMarkdownToLexical.ts
@@ -262,10 +262,10 @@ export function importMdastTreeToLexical({ root, mdastRoot, visitors, ...descrip
     mdastNode: Mdast.RootContent | Mdast.Root,
     lexicalParent: LexicalNode,
     mdastParent: Mdast.Parent | null,
-    visitorToSkip?: MdastImportVisitor<Mdast.RootContent>
+    skipVisitors = new Set<number>()
   ) {
-    const visitor = visitors.find((visitor) => {
-      if (visitor === visitorToSkip) {
+    const visitor = visitors.find((visitor, index) => {
+      if (skipVisitors.has(index)) {
         return false
       }
       if (typeof visitor.testNode === 'string') {
@@ -296,7 +296,7 @@ export function importMdastTreeToLexical({ root, mdastRoot, visitors, ...descrip
       actions: {
         visitChildren,
         nextVisitor() {
-          visit(mdastNode, lexicalParent, mdastParent, visitor)
+          visit(mdastNode, lexicalParent, mdastParent, skipVisitors.add(visitors.indexOf(visitor)))
         },
         addAndStepInto(lexicalNode) {
           ;(lexicalParent as ElementNode).append(lexicalNode)

--- a/src/importMarkdownToLexical.ts
+++ b/src/importMarkdownToLexical.ts
@@ -105,6 +105,10 @@ export interface MdastImportVisitor<UN extends Mdast.Nodes> {
        * Access the current style context.
        */
       getParentStyle(): string
+      /**
+       * Skip the visitor to move along the visitors chain for potential processing from a different visitor with a lower priority
+       */
+      skip(): void
     }
   }): void
   /**
@@ -254,8 +258,16 @@ export function importMdastTreeToLexical({ root, mdastRoot, visitors, ...descrip
     })
   }
 
-  function visit(mdastNode: Mdast.RootContent | Mdast.Root, lexicalParent: LexicalNode, mdastParent: Mdast.Parent | null) {
+  function visit(
+    mdastNode: Mdast.RootContent | Mdast.Root,
+    lexicalParent: LexicalNode,
+    mdastParent: Mdast.Parent | null,
+    skipVisitor?: MdastImportVisitor<Mdast.RootContent>
+  ) {
     const visitor = visitors.find((visitor) => {
+      if (skipVisitor && visitor === skipVisitor) {
+        return false
+      }
       if (typeof visitor.testNode === 'string') {
         return visitor.testNode === mdastNode.type
       }
@@ -283,6 +295,9 @@ export function importMdastTreeToLexical({ root, mdastRoot, visitors, ...descrip
       metaData,
       actions: {
         visitChildren,
+        skip() {
+          visit(mdastNode, lexicalParent, mdastParent, visitor)
+        },
         addAndStepInto(lexicalNode) {
           ;(lexicalParent as ElementNode).append(lexicalNode)
           if (isParent(mdastNode)) {

--- a/src/importMarkdownToLexical.ts
+++ b/src/importMarkdownToLexical.ts
@@ -106,9 +106,9 @@ export interface MdastImportVisitor<UN extends Mdast.Nodes> {
        */
       getParentStyle(): string
       /**
-       * Skip the visitor to move along the visitors chain for potential processing from a different visitor with a lower priority
+       * Go to next visitor in the visitors chain for potential processing from a different visitor with a lower priority
        */
-      skip(): void
+      nextVisitor(): void
     }
   }): void
   /**
@@ -262,10 +262,10 @@ export function importMdastTreeToLexical({ root, mdastRoot, visitors, ...descrip
     mdastNode: Mdast.RootContent | Mdast.Root,
     lexicalParent: LexicalNode,
     mdastParent: Mdast.Parent | null,
-    skipVisitor?: MdastImportVisitor<Mdast.RootContent>
+    visitorToSkip?: MdastImportVisitor<Mdast.RootContent>
   ) {
     const visitor = visitors.find((visitor) => {
-      if (skipVisitor && visitor === skipVisitor) {
+      if (visitor === visitorToSkip) {
         return false
       }
       if (typeof visitor.testNode === 'string') {
@@ -295,7 +295,7 @@ export function importMdastTreeToLexical({ root, mdastRoot, visitors, ...descrip
       metaData,
       actions: {
         visitChildren,
-        skip() {
+        nextVisitor() {
           visit(mdastNode, lexicalParent, mdastParent, visitor)
         },
         addAndStepInto(lexicalNode) {


### PR DESCRIPTION
A new skip function added to actions of the visitors for both markdown import and export visits

This is helpful when extending via `addImportVisitor` or `addExportVistor`, you may want to inspect(/and modify) the tree but allow further processing from the visitors already in place 

```typescript

const LogMdastTextVisitor: MdastImportVisitor<Mdast.Text> = {
  testNode: "text",
  visitNode({ mdastNode, actions }) {
    console.log(`TEXT NODE: ${mdastNode.value} at ${mdastNode.position?.start.line}:${mdastNode.position?.start.column}`);
    actions.skip();
  },
  priority: 1000,
};

```

Also `actions.next` may be more appropriate 