### PR TITLE
export lexical so it can be used during extension

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -121,3 +121,6 @@ export * from './RealmWithPlugins'
 export * from './FormatConstants'
 
 export * from './styles/lexicalTheme'
+
+import * as lexical from 'lexical'
+export { lexical }


### PR DESCRIPTION
It would be nice to share the lexical module used internally, this is especially handy during some extensions. Maintaining another lexical dep in my project is a bit hairy. _I think i'm doing this right?_

I feel like this should be fine as long as the lexical export is properly tree shaken