### PR TITLE
fix: update placeholder rendering in RichTextEditor component

### DIFF
--- a/src/MDXEditor.tsx
+++ b/src/MDXEditor.tsx
@@ -81,7 +81,7 @@ const RichTextEditor: React.FC = () => {
             }
             placeholder={
               <div className={classNames(styles.contentEditable, styles.placeholder, contentEditableClassName)}>
-                <p>{placeholder}</p>
+                {placeholder}
               </div>
             }
             ErrorBoundary={LexicalErrorBoundary}


### PR DESCRIPTION
# Fix: Remove unnecessary `<p>` tags from input placeholders

Description:
Currently, placeholders wrap content in `<p>` tags, which is invalid since placeholders cannot contain block-level elements like `<div>` or `<p>`. This PR removes the automatic `<p>` wrapping, ensuring that only plain text is used in placeholders.

Impact:

- Fixes invalid HTML in input fields
- Prevents rendering issues in browsers that strictly enforce placeholder content rules