### PR TITLE
Upgrade js-yaml

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -39,7 +39,7 @@
         "cm6-theme-basic-light": "^0.2.0",
         "codemirror": "^6.0.1",
         "downshift": "^7.6.0",
-        "js-yaml": "4.1.0",
+        "js-yaml": "4.1.1",
         "lexical": "^0.35.0",
         "mdast-util-directive": "^3.0.0",
         "mdast-util-from-markdown": "^2.0.0",
@@ -12865,9 +12865,10 @@
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
     },
     "node_modules/js-yaml": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
       },

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "cm6-theme-basic-light": "^0.2.0",
     "codemirror": "^6.0.1",
     "downshift": "^7.6.0",
-    "js-yaml": "4.1.0",
+    "js-yaml": "4.1.1",
     "lexical": "^0.35.0",
     "mdast-util-directive": "^3.0.0",
     "mdast-util-from-markdown": "^2.0.0",


### PR DESCRIPTION
There's a moderate security vulnerability in js-yaml v4.1.0, which is fixed in v4.1.1

https://github.com/advisories/GHSA-mh29-5h37-fv8m

I hope this is a helpful PR and that I'm not stepping on anyone's toes with it