### PR TITLE
fix: link dialog tooltip active when text selection is true

### DIFF
--- a/src/plugins/link-dialog/index.ts
+++ b/src/plugins/link-dialog/index.ts
@@ -248,7 +248,7 @@ export const linkDialogState$ = Cell<InactiveLinkDialog | PreviewLinkDialog | Ed
       map(([[selection], activeEditor, _, readOnly]) => {
         if ($isRangeSelection(selection) && activeEditor && !readOnly) {
           const node = getLinkNodeInSelection(selection)
-
+          if (!selection.isCollapsed()) return { type: 'inactive' } as InactiveLinkDialog
           if (node) {
             const rect = getSelectionRectangle(activeEditor)
 


### PR DESCRIPTION
Bug: Link Dialog Tooltip appears when text is selected that **includes** the link anchor text.
Fix: Added a simple if condition that detects if text selection is true -> makes the dialog tooltip inactive.

closes #721 