### PR TITLE
fix: Allow changing anchor text without affecting url

### DIFF
--- a/src/plugins/link-dialog/index.ts
+++ b/src/plugins/link-dialog/index.ts
@@ -1,4 +1,4 @@
-import { $createLinkNode, $isLinkNode, LinkNode, TOGGLE_LINK_COMMAND } from '@lexical/link'
+import { $createLinkNode, $isAutoLinkNode, $isLinkNode, LinkNode, TOGGLE_LINK_COMMAND } from '@lexical/link'
 import { Action, Cell, Signal, filter, map, withLatestFrom } from '@mdxeditor/gurx'
 import { JSX } from 'react'
 import {
@@ -183,9 +183,16 @@ export const linkDialogState$ = Cell<InactiveLinkDialog | PreviewLinkDialog | Ed
               $insertNodes([node])
               node.select()
             } else {
-              linkNode.setURL(url)
-              linkNode.setTitle(title)
-              updateLinkText(linkNode.getFirstChild(), text)
+              if ($isAutoLinkNode(linkNode)) {
+                const newLinkNode = $createLinkNode(url, { title })
+                newLinkNode.append($createTextNode(text))
+                linkNode.replace(newLinkNode)
+                newLinkNode.select()
+              } else {
+                linkNode.setURL(url)
+                linkNode.setTitle(title)
+                updateLinkText(linkNode.getFirstChild(), text)
+              }
             }
           },
           { discrete: true }


### PR DESCRIPTION
Fixes an issue where editing the anchor text of an auto linked URL, would also change the url on save because Lexicals AutoLinkNode makes sure that the text content matches the URL.

```
mdx editor
https://google.com
end
```
For testing scenario, copy paste the above string content and change the anchor text (only), it will change the url too, to match the text. This PR is a fix to that.

Changes: 
In` updateLink$`, added a check on save for if `$isAutoLinkNode`, the node is replaced with a standard LinkNode during the update. This decouples the anchor text from the URL.

closes #893 