### PR TITLE
fix: preserve image dimensions on copy/paste

### DIFF
--- a/src/plugins/image/ImageNode.tsx
+++ b/src/plugins/image/ImageNode.tsx
@@ -18,7 +18,7 @@ import { MdxJsxAttribute, MdxJsxExpressionAttribute } from 'mdast-util-mdx-jsx'
 function convertImageElement(domNode: Node): null | DOMConversionOutput {
   if (domNode instanceof HTMLImageElement) {
     const { alt: altText, src, title, width, height } = domNode
-    const node = $createImageNode({ altText, src, title, width, height })
+    const node = $createImageNode({ altText, src, title, width: width || undefined, height: height || undefined })
     return { node }
   }
   return null
@@ -104,10 +104,10 @@ export class ImageNode extends DecoratorNode<JSX.Element> {
     if (this.__title) {
       element.setAttribute('title', this.__title)
     }
-    if (this.__width) {
+    if (this.__width !== 'inherit' && this.__width) {
       element.setAttribute('width', this.__width.toString())
     }
-    if (this.__height) {
+    if (this.__height !== 'inherit' && this.__height) {
       element.setAttribute('height', this.__height.toString())
     }
     return { element }
@@ -150,8 +150,8 @@ export class ImageNode extends DecoratorNode<JSX.Element> {
     return {
       altText: this.getAltText(),
       title: this.getTitle(),
-      height: this.__height === 'inherit' ? 0 : this.__height,
-      width: this.__width === 'inherit' ? 0 : this.__width,
+      height: this.__height === 'inherit' ? undefined : this.__height,
+      width: this.__width === 'inherit' ? undefined : this.__width,
       src: this.getSrc(),
       rest: this.__rest,
       type: 'image',

--- a/src/plugins/image/MdastImageVisitor.ts
+++ b/src/plugins/image/MdastImageVisitor.ts
@@ -40,8 +40,8 @@ export const MdastHtmlImageVisitor: MdastImportVisitor<Mdast.Html> = {
       src: src || '',
       altText,
       title,
-      width,
-      height
+      width: width || undefined,
+      height: height || undefined
     })
 
     if (lexicalParent.getType() === 'root') {


### PR DESCRIPTION
## Summary

- When copying and pasting images in the editor, pasted images had `width: 0` and `height: 0` instead of inheriting dimensions
- **`exportJSON()`** converted `'inherit'` to `0`, which `importJSON()` stored as `0` (since `0 ?? 'inherit'` evaluates to `0`)
- **`exportDOM()`** wrote `width="inherit"` as an HTML attribute, which browsers parse as `0`
- **`convertImageElement()`** and **`MdastHtmlImageVisitor`** read `HTMLImageElement.width`/`.height` which return `0` for detached elements without explicit attributes

## Test plan

- [ ] Open HtmlImage story, copy an image (Cmd+C), paste it (Cmd+V) — dimensions should be preserved
- [ ] Copy an image from an external source and paste — should not get `width="0" height="0"`
- [ ] Images with explicit width/height attributes should still preserve their dimensions after copy/paste