### PR TITLE
Fixing theme problem - Replacing hard coded white color with css variable

### DIFF
--- a/src/styles/ui.module.css
+++ b/src/styles/ui.module.css
@@ -64,7 +64,7 @@
   --accentText: var(--blue-11);
   --accentTextContrast: var(--blue-12);
 
-  --basePageBg: white;
+  --basePageBg: var(--slate-3);
   --baseBase: var(--slate-1);
   --baseBgSubtle: var(--slate-2);
   --baseBg: var(--slate-3);


### PR DESCRIPTION
Fixing #921 

This pull request makes a small change to the UI color theme by updating the background color variable.

* Changed `--basePageBg` from `white` to `var(--slate-3)` in `src/styles/ui.module.css` to better align with the slate color palette.