### PR TITLE
fix: add aria-label to toolbar buttons for WCAG 2.2 AA compliance

### DIFF
--- a/src/plugins/toolbar/components/InsertImage.tsx
+++ b/src/plugins/toolbar/components/InsertImage.tsx
@@ -18,6 +18,7 @@ export const InsertImage = React.forwardRef<HTMLButtonElement, Record<string, ne
 
   return (
     <RadixToolbar.Button
+      aria-label={t('toolbar.image', 'Insert image')}
       className={styles.toolbarButton}
       ref={forwardedRef}
       disabled={readOnly}

--- a/src/plugins/toolbar/primitives/DialogButton.tsx
+++ b/src/plugins/toolbar/primitives/DialogButton.tsx
@@ -5,7 +5,7 @@ import React from 'react'
 
 import classNames from 'classnames'
 import { useCombobox } from 'downshift'
-import { editorRootElementRef$, iconComponentFor$, readOnly$ } from '../../core'
+import { editorRootElementRef$, iconComponentFor$, readOnly$, useTranslation } from '../../core'
 import styles from '../../../styles/ui.module.css'
 import { TooltipWrap } from './TooltipWrap'
 import { useCellValue, useCellValues } from '@mdxeditor/gurx'
@@ -63,7 +63,7 @@ export const DialogButton = React.forwardRef<
   return (
     <Dialog.Root open={open} onOpenChange={setOpen}>
       <Dialog.Trigger asChild>
-        <RadixToolbar.Button className={styles.toolbarButton} ref={forwardedRef} disabled={readOnly}>
+        <RadixToolbar.Button aria-label={tooltipTitle} className={styles.toolbarButton} ref={forwardedRef} disabled={readOnly}>
           <TooltipWrap title={tooltipTitle}>{buttonContent}</TooltipWrap>
         </RadixToolbar.Button>
       </Dialog.Trigger>
@@ -90,6 +90,7 @@ const DialogForm: React.FC<{
 }> = ({ autocompleteSuggestions, onSubmitCallback, dialogInputPlaceholder, submitButtonTitle }) => {
   const [items, setItems] = React.useState(autocompleteSuggestions.slice(0, MAX_SUGGESTIONS))
   const iconComponentFor = useCellValue(iconComponentFor$)
+  const t = useTranslation()
 
   const enableAutoComplete = autocompleteSuggestions.length > 0
 
@@ -190,7 +191,9 @@ const DialogForm: React.FC<{
         {iconComponentFor('check')}
       </button>
 
-      <Dialog.Close className={styles.actionButton}>{iconComponentFor('close')}</Dialog.Close>
+      <Dialog.Close aria-label={t('dialog.close', 'Close dialog')} className={styles.actionButton}>
+        {iconComponentFor('close')}
+      </Dialog.Close>
     </form>
   )
 }

--- a/src/plugins/toolbar/primitives/select.tsx
+++ b/src/plugins/toolbar/primitives/select.tsx
@@ -76,7 +76,7 @@ export const SelectButtonTrigger: React.FC<{ children: React.ReactNode; title: s
   const [readOnly, iconComponentFor] = useCellValues(readOnly$, iconComponentFor$)
   return (
     <TooltipWrap title={title}>
-      <RadixSelect.Trigger className={classNames(styles.toolbarButtonSelectTrigger, className)} disabled={readOnly}>
+      <RadixSelect.Trigger aria-label={title} className={classNames(styles.toolbarButtonSelectTrigger, className)} disabled={readOnly}>
         {children}
         <RadixSelect.Icon className={styles.selectDropdownArrow}>{iconComponentFor('arrow_drop_down')}</RadixSelect.Icon>
       </RadixSelect.Trigger>

--- a/src/plugins/toolbar/primitives/toolbar.tsx
+++ b/src/plugins/toolbar/primitives/toolbar.tsx
@@ -30,7 +30,7 @@ function decorateWithRef<P extends { className?: string | undefined }>(
 function addTooltipToChildren<C extends React.ComponentType<{ children: React.ReactNode }>>(Component: C) {
   return ({ title, children, ...props }: React.ComponentProps<C> & { title: string }) => {
     return (
-      <Component {...(props as any)}>
+      <Component aria-label={title} {...(props as any)}>
         <TooltipWrap title={title}>{children}</TooltipWrap>
       </Component>
     )

--- a/src/test/toolbar.test.tsx
+++ b/src/test/toolbar.test.tsx
@@ -1,0 +1,54 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import React from 'react'
+import { describe, expect, it } from 'vitest'
+import { MDXEditor } from '../MDXEditor'
+import { InsertImage } from '../plugins/toolbar/components/InsertImage'
+import { DialogButton } from '../plugins/toolbar/primitives/DialogButton'
+import { ButtonOrDropdownButton, ButtonWithTooltip } from '../plugins/toolbar/primitives/toolbar'
+import { toolbarPlugin } from '../plugins/toolbar'
+
+describe('toolbar accessibility', () => {
+  it('exposes accessible names for icon-only toolbar controls', () => {
+    render(
+      <MDXEditor
+        markdown=""
+        plugins={[
+          toolbarPlugin({
+            toolbarContents: () => (
+              <>
+                <ButtonWithTooltip title="Insert code block">code</ButtonWithTooltip>
+                <ButtonOrDropdownButton
+                  title="Insert admonition"
+                  onChoose={() => undefined}
+                  items={[
+                    { value: 'note', label: 'Note' },
+                    { value: 'tip', label: 'Tip' }
+                  ]}
+                >
+                  admonition
+                </ButtonOrDropdownButton>
+                <DialogButton
+                  tooltipTitle="Insert YouTube video"
+                  dialogInputPlaceholder="Paste URL"
+                  submitButtonTitle="Insert video"
+                  onSubmit={() => undefined}
+                  buttonContent="video"
+                />
+                <InsertImage />
+              </>
+            )
+          })
+        ]}
+      />
+    )
+
+    expect(screen.getByRole('button', { name: 'Insert code block' })).toBeInTheDocument()
+    expect(screen.getByLabelText('Insert admonition')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Insert YouTube video' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Insert image' })).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Insert YouTube video' }))
+
+    expect(screen.getByRole('button', { name: 'Close dialog' })).toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
## Summary

- add `aria-label` wiring for icon-only toolbar buttons that previously relied on visual tooltips alone
- extend the same accessibility fix to dropdown toolbar triggers, dialog trigger buttons, the insert image button, and the dialog close button
- add a regression test that renders real toolbar controls and asserts their accessible names

Closes #924

## Test plan

- [x] Run `npm run test:once -- src/test/toolbar.test.tsx`
- [x] Verify icon-only toolbar buttons and triggers are queryable by accessible name in the regression test
- [ ] Run an accessibility checker on the full toolbar surface in the browser if needed