### PR TITLE
fix: route capitalized jsx tags sharing an html tag name to the jsx visitor

### DIFF
--- a/src/examples/jsx.tsx
+++ b/src/examples/jsx.tsx
@@ -331,3 +331,29 @@ Hello from <Buzz />
     </div>
   )
 }
+
+const htmlTagNameDescriptors: JsxComponentDescriptor[] = [
+  {
+    name: 'Section',
+    kind: 'text',
+    source: './external',
+    props: [
+      { name: 'foo', type: 'string' },
+      { name: 'bar', type: 'string' }
+    ],
+    hasChildren: true,
+    Editor: GenericJsxEditor
+  }
+]
+
+export const HtmlTagNames = () => {
+  const markdown = `Known jsx component with name of HTML tag:
+
+<Section>Section content</Section>
+
+Unknown jsx component with name of HTML tag:
+
+<Button>Click me</Button>
+`
+  return <MDXEditor markdown={markdown} plugins={[jsxPlugin({ jsxComponentDescriptors: htmlTagNameDescriptors })]} />
+}

--- a/src/plugins/core/MdastHTMLNode.ts
+++ b/src/plugins/core/MdastHTMLNode.ts
@@ -44,7 +44,7 @@ export type MdxNodeType = MdastHTMLNode['type']
 export function isMdastHTMLNode(node: Mdast.Nodes): node is MdastHTMLNode {
   return (
     MDX_NODE_TYPES.includes(node.type as unknown as MdxNodeType) &&
-    (htmlTags as readonly string[]).includes((node as MdastHTMLNode).name.toLowerCase())
+    (htmlTags as readonly string[]).includes((node as MdastHTMLNode).name)
   )
 }
 

--- a/src/plugins/jsx/LexicalJsxVisitor.ts
+++ b/src/plugins/jsx/LexicalJsxVisitor.ts
@@ -3,7 +3,7 @@ import { $isLexicalJsxNode, LexicalJsxNode } from './LexicalJsxNode'
 import { LexicalExportVisitor } from '../../exportMarkdownFromLexical'
 import * as Mdast from 'mdast'
 import { isMdastJsxNode } from '.'
-import { htmlTags } from '../core'
+import { isHtmlTagName } from './jsxTagName'
 
 export const LexicalJsxVisitor: LexicalExportVisitor<LexicalJsxNode, MdxJsxFlowElement | MdxJsxTextElement> = {
   testLexicalNode: $isLexicalJsxNode,
@@ -11,7 +11,7 @@ export const LexicalJsxVisitor: LexicalExportVisitor<LexicalJsxNode, MdxJsxFlowE
     function traverseNestedJsxNodes(node: Mdast.Nodes) {
       if ('children' in node && node.children instanceof Array) {
         node.children.forEach((child: Mdast.Nodes) => {
-          if (isMdastJsxNode(child) && !htmlTags.includes(child.name!.toLowerCase())) {
+          if (isMdastJsxNode(child) && !isHtmlTagName(child.name!)) {
             actions.registerReferredComponent(child.name!)
           }
           traverseNestedJsxNodes(child)

--- a/src/plugins/jsx/jsxTagName.ts
+++ b/src/plugins/jsx/jsxTagName.ts
@@ -1,0 +1,5 @@
+import { htmlTags } from '../core/MdastHTMLNode'
+
+export function isHtmlTagName(name: string): boolean {
+  return (htmlTags as readonly string[]).includes(name)
+}

--- a/src/test/jsx.test.tsx
+++ b/src/test/jsx.test.tsx
@@ -34,4 +34,27 @@ describe('jsx markdown import export', () => {
     const processedMarkdown = ref.current?.getMarkdown().trim()
     expect(processedMarkdown).toEqual(markdown.trim())
   })
+
+  it('routes capitalized jsx components sharing an html tag name to the jsx visitor', () => {
+    const descriptors: JsxComponentDescriptor[] = [
+      {
+        name: 'Section',
+        kind: 'text',
+        props: [],
+        hasChildren: true,
+        Editor: GenericJsxEditor
+      }
+    ]
+    const { container } = render(
+      <MDXEditor markdown={`<Section>Section content</Section>`} plugins={[jsxPlugin({ jsxComponentDescriptors: descriptors })]} />
+    )
+    expect(container.querySelector('section')).toBeNull()
+  })
+
+  it('keeps lowercase html tag names on the html path even with a jsx plugin', () => {
+    const { container } = render(
+      <MDXEditor markdown={`<section>Section content</section>`} plugins={[jsxPlugin({ jsxComponentDescriptors: [] })]} />
+    )
+    expect(container.querySelector('section')).not.toBeNull()
+  })
 })

--- a/src/test/jsx.test.tsx
+++ b/src/test/jsx.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import { GenericJsxEditor, JsxComponentDescriptor, MDXEditor, MDXEditorMethods, jsxPlugin } from '../'
 import { render, act } from '@testing-library/react'
 
@@ -18,6 +18,10 @@ const jsxComponentDescriptors: JsxComponentDescriptor[] = [
     Editor: GenericJsxEditor
   }
 ]
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
 
 describe('jsx markdown import export', () => {
   // produces a warning about act
@@ -56,5 +60,37 @@ describe('jsx markdown import export', () => {
       <MDXEditor markdown={`<section>Section content</section>`} plugins={[jsxPlugin({ jsxComponentDescriptors: [] })]} />
     )
     expect(container.querySelector('section')).not.toBeNull()
+  })
+
+  it('registers nested capitalized JSX children that share an html tag name on export', async () => {
+    const ref = React.createRef<MDXEditorMethods>()
+    const descriptors: JsxComponentDescriptor[] = [
+      {
+        name: 'Wrapper',
+        kind: 'text',
+        source: './components',
+        props: [],
+        hasChildren: true,
+        Editor: GenericJsxEditor
+      },
+      {
+        name: 'Section',
+        kind: 'text',
+        source: './components',
+        props: [],
+        hasChildren: false,
+        Editor: GenericJsxEditor
+      }
+    ]
+
+    act(() => {
+      render(<MDXEditor ref={ref} markdown={`<Wrapper><Section /></Wrapper>`} plugins={[jsxPlugin({ jsxComponentDescriptors: descriptors })]} />)
+    })
+    await new Promise((resolve) => setTimeout(resolve, 100))
+
+    const processedMarkdown = ref.current?.getMarkdown() ?? ''
+
+    expect(processedMarkdown).toContain(`import { Wrapper, Section } from './components'`)
+    expect(processedMarkdown).toContain(`<Wrapper><Section /></Wrapper>`)
   })
 })


### PR DESCRIPTION
## Summary

- `isMdastHTMLNode` lowercased the element name before matching against `htmlTags`, so `<Section>` (and any capitalized tag whose lowercase form is an HTML element) was routed to the HTML visitor (priority -100) before the JSX visitor (priority -200) could consult the registered `JsxComponentDescriptor`. The descriptor's `Editor` was never rendered.
- MDX convention treats capitalized tag names as components; `htmlTags` only contains lowercase entries, so the `.toLowerCase()` is unnecessary and the case-sensitive check restores the expected routing. `<section>` still goes through the HTML path.
- Added a `HtmlTagNames` Ladle example that registers a `Section` descriptor alongside an unregistered `<Button>` to exercise both branches.
- Added two regression tests in `src/test/jsx.test.tsx`.

## Test plan

- [x] `npm run typecheck`
- [x] `npm run test:once`
- [x] Confirmed the new test fails without the fix and passes with it