### PR TITLE
fix: respect allowed heading levels in shortcuts

### DIFF
--- a/src/plugins/headings/index.ts
+++ b/src/plugins/headings/index.ts
@@ -79,13 +79,14 @@ export const headingsPlugin = realmPlugin<{
    */
   allowedHeadingLevels?: readonly HEADING_LEVEL[]
 }>({
-  init(realm) {
+  init(realm, params) {
     realm.pubIn({
       [addActivePlugin$]: 'headings',
       [addImportVisitor$]: MdastHeadingVisitor,
       [addLexicalNode$]: HeadingNode,
       [addExportVisitor$]: LexicalHeadingVisitor
     })
+    realm.pub(allowedHeadingLevels$, params?.allowedHeadingLevels ?? ALL_HEADING_LEVELS)
   },
   update(realm, params) {
     realm.pub(allowedHeadingLevels$, params?.allowedHeadingLevels ?? ALL_HEADING_LEVELS)

--- a/src/test/markdown-shortcut.test.tsx
+++ b/src/test/markdown-shortcut.test.tsx
@@ -1,0 +1,39 @@
+import React from 'react'
+import { describe, expect, it } from 'vitest'
+import type { ElementTransformer, Transformer } from '@lexical/markdown'
+import { HeadingNode } from '@lexical/rich-text'
+import { Realm } from '@mdxeditor/gurx'
+import { composerChildren$ } from '../plugins/core'
+import { headingsPlugin, type HEADING_LEVEL } from '../plugins/headings'
+import { markdownShortcutPlugin } from '../plugins/markdown-shortcut'
+
+function headingShortcutRegExp(allowedHeadingLevels: readonly HEADING_LEVEL[]) {
+  const realm = new Realm()
+
+  headingsPlugin({ allowedHeadingLevels }).init?.(realm)
+  markdownShortcutPlugin().init?.(realm)
+
+  const ShortcutChild = realm.getValue(composerChildren$)[0] as () => React.ReactElement<{ transformers: Transformer[] }>
+  const shortcutElement = ShortcutChild()
+  const headingTransformer = shortcutElement.props.transformers.find((transformer): transformer is ElementTransformer => {
+    return (
+      'regExp' in transformer &&
+      'dependencies' in transformer &&
+      transformer.dependencies.includes(HeadingNode) &&
+      transformer.type === 'element'
+    )
+  })
+
+  expect(headingTransformer).toBeDefined()
+  return headingTransformer!.regExp
+}
+
+describe('markdownShortcutPlugin', () => {
+  it('uses configured heading levels during plugin initialization', () => {
+    const regExp = headingShortcutRegExp([1, 2])
+
+    expect('# ').toMatch(regExp)
+    expect('## ').toMatch(regExp)
+    expect('### ').not.toMatch(regExp)
+  })
+})


### PR DESCRIPTION
## Summary
- publish the configured heading levels during `headingsPlugin` initialization
- add a regression test covering the markdown shortcut heading transformer built during plugin init

## Root cause
`markdownShortcutPlugin` builds its transformers in `init` and reads `allowedHeadingLevels$` at that point. `headingsPlugin` previously published custom `allowedHeadingLevels` only from `update`, so markdown shortcuts saw the default heading range during initialization.

Fixes #946.

## Verification
- Regression test failed before the fix with `expected '### ' not to match /^(#{1,6})\s/`
- `npm run lint`
- `npm run typecheck`
- `npm run test:once`
- `npm run build`
- `npm run test:package`
- `git diff --check`
