### PR TITLE
Upgrade js-yaml to 4.3.0 to resolve high vulnerability

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -40,7 +40,7 @@
         "cm6-theme-basic-light": "^0.2.0",
         "codemirror": "^6.0.1",
         "downshift": "^7.6.0",
-        "js-yaml": "4.2.0",
+        "js-yaml": "4.3.0",
         "lexical": "^0.48.0",
         "mdast-util-directive": "^3.0.0",
         "mdast-util-from-markdown": "^2.0.0",
@@ -13476,9 +13476,9 @@
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
     },
     "node_modules/js-yaml": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
-      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
       "funding": [
         {
           "type": "github",
@@ -13489,6 +13489,7 @@
           "url": "https://github.com/sponsors/nodeca"
         }
       ],
+      "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
       },

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "cm6-theme-basic-light": "^0.2.0",
     "codemirror": "^6.0.1",
     "downshift": "^7.6.0",
-    "js-yaml": "4.2.0",
+    "js-yaml": "4.3.0",
     "lexical": "^0.48.0",
     "mdast-util-directive": "^3.0.0",
     "mdast-util-from-markdown": "^2.0.0",


### PR DESCRIPTION
Before upgrade, `npm audit` shows the vulnerability:
```
% npm audit --omit=dev
...

js-yaml  4.0.0 - 4.2.0
Severity: high
js-yaml: YAML merge-key chains can force quadratic CPU consumption - https://github.com/advisories/GHSA-52cp-r559-cp3m
fix available via `npm audit fix --force`
Will install js-yaml@4.3.0, which is outside the stated dependency range
node_modules/js-yaml

...
```

Upgrading to 4.3.0 resolves the js-yaml vulnerability.