### PR TITLE
fix(link-dialog): don't crash when the selection rectangle is unavailable

### DIFF
--- a/src/plugins/link-dialog/index.ts
+++ b/src/plugins/link-dialog/index.ts
@@ -348,7 +348,11 @@ export const openLinkEditDialog$ = Action((r) => {
         setTimeout(() => {
           editor.getEditorState().read(() => {
             const linkNode = getLinkNodeInSelection(selection)
-            const rectangle = getSelectionRectangle(editor)!
+            // getSelectionRectangle returns null when the native DOM selection is not inside
+            // the editor (e.g. an image node is selected). Fall back to the editor's own
+            // rectangle so the dialog still opens instead of crashing (#753).
+            const rectangle: RectData = getSelectionRectangle(editor) ??
+              editor.getRootElement()?.getBoundingClientRect() ?? { top: 0, left: 0, width: 0, height: 0 }
             const initialUrl = linkNode?.getURL() ?? ''
             const url = linkNode?.getURL() ?? ''
             const title = linkNode?.getTitle() ?? ''


### PR DESCRIPTION
## Summary

Fixes #753 — clicking the **Create Link** toolbar button while an image is selected crashes the whole editor with `TypeError: Cannot read properties of null (reading 'top')` (reproducible on the official demo).

## Root cause

`getSelectionRectangle()` returns `null` when the native DOM selection is not inside the editor root element — which is the case when an image (decorator node) holds the selection, since the Lexical selection and the native selection diverge there (as noted in #753). `openLinkEditDialog$` force-asserts the result as non-null:

```ts
const rectangle = getSelectionRectangle(editor)!
```

so a state with `rectangle: null` reaches `LinkDialog`, which reads `theRect.top` and throws, unmounting the editor tree.

## Fix

Remove the non-null assertion and fall back to the editor root element's bounding rectangle, so the dialog still opens (anchored to the editor) instead of crashing. This follows the graceful-degradation behavior requested in #753, and mirrors the null handling that the link *preview* path already does a few lines above (which bails to `inactive` when `getSelectionRectangle` returns null).

## Testing

- `npm run typecheck` — clean
- `npx eslint src/plugins/link-dialog/index.ts` — clean
- `npm run test:once` — 79 passed, 1 skipped
- Manually verified the equivalent change against 3.52.1: insert an image → click Create Link → dialog opens anchored to the editor, no crash

🤖 Generated with [Claude Code](https://claude.com/claude-code)