### PR TITLE
fix: treat undefined markdown as empty string

### DIFF
--- a/src/MDXEditor.tsx
+++ b/src/MDXEditor.tsx
@@ -408,7 +408,9 @@ export const MDXEditor = React.forwardRef<MDXEditorMethods, MDXEditorProps>((pro
   const realmMethods = React.useRef<MDXEditorMethods | null>(null)
   const replayingRealmMethods = React.useRef<MDXEditorMethods | null>(null)
   const pendingMethodCalls = React.useRef<((methods: MDXEditorMethods) => void)[]>([])
-  const preReadyMarkdown = React.useRef(props.trim === false ? props.markdown : props.markdown.trim())
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- runtime markdown can be undefined/null
+  const initialMarkdown = props.markdown ?? ''
+  const preReadyMarkdown = React.useRef(props.trim === false ? initialMarkdown : initialMarkdown.trim())
   const callWhenReady = React.useCallback((call: (methods: MDXEditorMethods) => void) => {
     const methods = realmMethods.current
     if (methods && replayingRealmMethods.current === null) {

--- a/src/plugins/core/index.ts
+++ b/src/plugins/core/index.ts
@@ -370,15 +370,18 @@ export const setMarkdown$ = Signal<string>((r) => {
       setMarkdown$,
       withLatestFrom(markdown$, rootEditor$, inFocus$),
       filter(([newMarkdown, oldMarkdown]) => {
-        return newMarkdown.trim() !== oldMarkdown.trim()
+        // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- runtime values can be undefined
+        return (newMarkdown ?? '').trim() !== (oldMarkdown ?? '').trim()
       })
     ),
     ([theNewMarkdownValue, , editor, inFocus]) => {
+      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- runtime values can be undefined
+      const markdown = theNewMarkdownValue ?? ''
       r.pub(muteChange$, true)
       editor?.update(
         () => {
           $getRoot().clear()
-          tryImportingMarkdown(r, $getRoot(), theNewMarkdownValue)
+          tryImportingMarkdown(r, $getRoot(), markdown)
 
           if (!inFocus) {
             $setSelection(null)
@@ -1012,7 +1015,7 @@ export const corePlugin = realmPlugin<{
         params?.editorState === null
           ? null
           : () => {
-              const markdown = params?.initialMarkdown.trim() ?? ''
+              const markdown = (params?.initialMarkdown ?? '').trim()
               tryImportingMarkdown(r, $getRoot(), markdown)
             }
     })

--- a/src/test/core.test.tsx
+++ b/src/test/core.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { describe, expect, it, test, vi } from 'vitest'
 import { codeBlockPlugin, codeMirrorPlugin, MDXEditor, MDXEditorMethods, thematicBreakPlugin } from '../'
-import { render } from '@testing-library/react'
+import { act, render, waitFor } from '@testing-library/react'
 import { $getRoot, createEditor, ParagraphNode, TextNode } from 'lexical'
 import { QuoteNode } from '@lexical/rich-text'
 import { importMarkdownToLexical, type MarkdownParseOptions } from '../importMarkdownToLexical'
@@ -224,6 +224,31 @@ After fence.
     render(<MDXEditor ref={ref} markdown={'Before\n\n***\n\nAfter'} plugins={[thematicBreakPlugin()]} />)
 
     expect(ref.current?.getMarkdown().trim()).toEqual('Before\n\n***\n\nAfter')
+  })
+})
+
+describe('undefined markdown resilience', () => {
+  it('renders an empty editor when markdown is undefined', () => {
+    const ref = React.createRef<MDXEditorMethods>()
+    render(<MDXEditor ref={ref} markdown={undefined as unknown as string} />)
+    expect(ref.current?.getMarkdown().trim()).toEqual('')
+  })
+
+  it('renders an empty editor when markdown is null', () => {
+    const ref = React.createRef<MDXEditorMethods>()
+    render(<MDXEditor ref={ref} markdown={null as unknown as string} />)
+    expect(ref.current?.getMarkdown().trim()).toEqual('')
+  })
+
+  it('treats setMarkdown(undefined) as empty without throwing', async () => {
+    const ref = React.createRef<MDXEditorMethods>()
+    render(<MDXEditor ref={ref} markdown="hello" />)
+    act(() => {
+      ref.current?.setMarkdown(undefined as unknown as string)
+    })
+    await waitFor(() => {
+      expect(ref.current?.getMarkdown().trim()).toEqual('')
+    })
   })
 })
 


### PR DESCRIPTION
## Summary

MDXEditor crashed when `markdown` was `undefined`/`null`. Optional chaining only guarded `params`, so `params?.initialMarkdown.trim()` threw `Cannot read properties of undefined (reading 'trim')`.

Treat undefined/null as an empty string in `postInit` (same as `init`), `setMarkdown$`, and the pre-ready markdown path so the editor renders empty instead of throwing.

Fixes #803

## Test plan

- [x] `npx vitest --run src/test/core.test.tsx` (22 passed, including undefined/null markdown and `setMarkdown(undefined)`)
